### PR TITLE
feat: CR-2519  token fetch and axios intercept

### DIFF
--- a/src/auth/token-manager.ts
+++ b/src/auth/token-manager.ts
@@ -38,12 +38,13 @@ export class TokenManager {
       const tokens: StoredTokens = JSON.parse(tokensData);
 
       if (this.isTokenExpired(tokens)) {
+        logger.warn("Token expired");
         return null;
       }
 
       return tokens;
     } catch (error) {
-      logger.error(`Error getting tokens: ${String(error)}`);
+      logger.warn(`Error getting tokens: ${String(error)}`);
       return null;
     }
   }

--- a/src/lib/clients/axios/axios-client.ts
+++ b/src/lib/clients/axios/axios-client.ts
@@ -1,0 +1,56 @@
+import axios, { CreateAxiosDefaults } from "axios";
+import { CLITokenManager } from "./cli-token-mgr";
+import axiosRetry from "axios-retry";
+import { WebTokenManager } from "./web-token-mgr";
+import { env } from "../../env-schema";
+
+export interface TokenManager {
+  getToken: () => string;
+  resetToken: () => void;
+}
+
+const isCLi = env.RUNTIME_ENV === "CLI";
+
+export const createAxiosClient = (baseURL: string) => {
+  const opts: CreateAxiosDefaults = {
+    baseURL,
+  };
+
+  if (!isCLi) {
+    opts.withCredentials = true;
+  }
+
+  const axiosClient = axios.create(opts);
+
+  const tokenMgr: TokenManager = isCLi
+    ? new CLITokenManager()
+    : new WebTokenManager();
+
+  axiosClient.interceptors.request.use(function (config) {
+    const token = tokenMgr.getToken();
+    config.headers.Authorization = token ? `Bearer ${token}` : "";
+    return config;
+  });
+
+  axiosClient.interceptors.response.use(
+    function (response) {
+      return response;
+    },
+    function (error) {
+      if (error?.response?.status === 401) {
+        tokenMgr.resetToken();
+      }
+      if (error?.response?.status === 402) {
+        tokenMgr.resetToken();
+      }
+      return Promise.reject(error);
+    },
+  );
+
+  axiosRetry(axiosClient, {
+    retries: 3,
+    retryDelay: axiosRetry.exponentialDelay,
+  });
+
+  return axiosClient;
+};

--- a/src/lib/clients/axios/cli-token-mgr.ts
+++ b/src/lib/clients/axios/cli-token-mgr.ts
@@ -1,0 +1,18 @@
+import { TokenManager } from "./axios-client";
+import { TokenManager as AuthTokenManager } from "../../../auth/token-manager";
+
+export class CLITokenManager implements TokenManager {
+  private authTokenManager: AuthTokenManager;
+
+  constructor() {
+    this.authTokenManager = new AuthTokenManager();
+  }
+
+  getToken(): string {
+    return this.authTokenManager.getTokens()?.accessToken || "";
+  }
+
+  resetToken(): void {
+    this.authTokenManager.clearTokens();
+  }
+}

--- a/src/lib/clients/axios/web-token-mgr.ts
+++ b/src/lib/clients/axios/web-token-mgr.ts
@@ -1,0 +1,12 @@
+import { TokenManager } from "./axios-client";
+
+// Need to implement according to how we will run in the browser, probably using localStorage
+export class WebTokenManager implements TokenManager {
+  getToken(): string {
+    throw new Error("Not implemented");
+  }
+
+  resetToken(): void {
+    throw new Error("Not implemented");
+  }
+}

--- a/src/lib/clients/baz.ts
+++ b/src/lib/clients/baz.ts
@@ -1,6 +1,4 @@
-import axios from "axios";
-import axiosRetry from "axios-retry";
-import { OAuthFlow } from "../../auth/oauth-flow";
+import { createAxiosClient } from "./axios/axios-client";
 
 const BASE_URL = process.env.BASE_URL
   ? process.env.BASE_URL
@@ -14,8 +12,7 @@ const getDiscussionsUrl = (prId: string) =>
 const getDiscussionUrl = (discussionId: string) =>
   `${BASE_URL}/api/v1/discussions/${discussionId}`;
 
-axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
-
+const axiosClient = createAxiosClient(BASE_URL);
 export interface Repository {
   id: string;
   fullName: string;
@@ -27,13 +24,10 @@ export interface RepositoriesResponse {
 }
 
 export async function fetchRepositories(): Promise<Repository[]> {
-  const token = OAuthFlow.getInstance().getAccessToken();
-
-  const repos = await axios
+  const repos = await axiosClient
     .get<RepositoriesResponse>(REPOSITORIES_URL, {
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
       },
     })
     .then((value) => value.data)
@@ -57,13 +51,10 @@ export interface PullRequestsResponse {
 }
 
 export async function fetchPRs(repoId: string): Promise<PullRequest[]> {
-  const token = OAuthFlow.getInstance().getAccessToken();
-
-  const repos = await axios
+  const repos = await axiosClient
     .get<PullRequestsResponse>(PULL_REQUESTS_URL, {
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
       },
       // TODO: fix the extra repo ID needed here or adjust the API to allow both string and array of strings
       params: {
@@ -112,13 +103,10 @@ export interface DiscussionsResponse {
 }
 
 export async function fetchDiscussions(prId: string): Promise<Discussion[]> {
-  const token = OAuthFlow.getInstance().getAccessToken();
-
-  const repos = await axios
+  const repos = await axiosClient
     .get<DiscussionsResponse>(getDiscussionsUrl(prId), {
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
       },
       params: {
         state: "pending",
@@ -138,9 +126,7 @@ export async function postDiscussionReply(
   body: string,
   prId: string,
 ) {
-  const token = OAuthFlow.getInstance().getAccessToken();
-
-  await axios
+  await axiosClient
     .post(
       COMMENTS_URL,
       {
@@ -152,7 +138,6 @@ export async function postDiscussionReply(
       {
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
       },
     )
@@ -163,9 +148,7 @@ export async function postDiscussionReply(
 }
 
 export async function updateDiscussionState(discussionId: string) {
-  const token = OAuthFlow.getInstance().getAccessToken();
-
-  await axios
+  await axiosClient
     .patch(
       getDiscussionUrl(discussionId),
       {
@@ -174,7 +157,6 @@ export async function updateDiscussionState(discussionId: string) {
       {
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
       },
     )

--- a/src/lib/env-schema.ts
+++ b/src/lib/env-schema.ts
@@ -14,6 +14,7 @@ const envSchema = z.object({
   DESCOPE_PROJECT_ID: z.string(),
   DESCOPE_CLIENT_ID: z.string(),
   DESCOPE_REDIRECT_URI: z.string().default("http://localhost:8080/callback"),
+  RUNTIME_ENV: z.enum(["CLI", "WEB"]).default("CLI"),
 });
 
 export const env = envSchema.parse(process.env);


### PR DESCRIPTION
# Generated description
```mermaid
graph LR
fetchRepositories_("fetchRepositories"):::modified
axiosClient_("axiosClient"):::added
fetchPRs_("fetchPRs"):::modified
fetchDiscussions_("fetchDiscussions"):::modified
postDiscussionReply_("postDiscussionReply"):::modified
updateDiscussionState_("updateDiscussionState"):::modified
createAxiosClient_("createAxiosClient"):::added
CLITokenManager_("CLITokenManager"):::added
WebTokenManager_("WebTokenManager"):::added
RUNTIME_ENV_("RUNTIME_ENV"):::added
fetchRepositories_ -- "Refactored to use axiosClient with token management" --> axiosClient_
fetchRepositories_ -- "Sends GET request with automatic auth token handling" --> axiosClient_
fetchPRs_ -- "Refactored to use axiosClient with token management" --> axiosClient_
fetchPRs_ -- "Sends GET request with automatic auth token handling" --> axiosClient_
fetchDiscussions_ -- "Refactored to use axiosClient with token management" --> axiosClient_
fetchDiscussions_ -- "Sends GET request with automatic auth token handling" --> axiosClient_
postDiscussionReply_ -- "Refactored to use axiosClient with token management" --> axiosClient_
postDiscussionReply_ -- "Sends POST request with automatic auth token handling" --> axiosClient_
updateDiscussionState_ -- "Refactored to use axiosClient with token management" --> axiosClient_
updateDiscussionState_ -- "Sends PATCH request with automatic auth token handling" --> axiosClient_
createAxiosClient_ -- "Adds CLI token manager for authentication handling" --> CLITokenManager_
createAxiosClient_ -- "Adds Web token manager for browser authentication" --> WebTokenManager_
createAxiosClient_ -- "Uses RUNTIME_ENV to select token manager environment" --> RUNTIME_ENV_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Introduces a centralized <code>axios</code> client factory (<code>createAxiosClient</code>) that automatically injects authentication tokens into requests and handles token invalidation on 401/402 responses. Refactors existing API calls in <code>baz.ts</code> to utilize this new client, abstracting token management for different runtime environments via <code>CLITokenManager</code> and <code>WebTokenManager</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/3?tool=ast&topic=Logging+Update>Logging Update</a>
        </td><td>Changes the logging level in <code>TokenManager</code> from <code>error</code> to <code>warn</code> when tokens are expired or cannot be retrieved, reflecting a less severe issue.<details><summary>Modified files (1)</summary><ul><li>src/auth/token-manager.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>CR-2519-oauth-flow-1</td><td>October 05, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/3?tool=ast&topic=Axios+Client+Setup>Axios Client Setup</a>
        </td><td>Configures a centralized <code>axios</code> client factory (<code>createAxiosClient</code>) to automatically inject authentication tokens into requests and invalidate them on 401/402 responses, using environment-specific token managers like <code>CLITokenManager</code>.<details><summary>Modified files (5)</summary><ul><li>src/lib/clients/axios/cli-token-mgr.ts</li>
<li>src/lib/clients/axios/axios-client.ts</li>
<li>src/lib/clients/baz.ts</li>
<li>src/lib/clients/axios/web-token-mgr.ts</li>
<li>src/lib/env-schema.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>CR-2547-add-discussion...</td><td>October 08, 2025</td></tr>
<tr><td>yuvalyacoby</td><td>CR-2519-oauth-flow-1</td><td>October 05, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/3?tool=ast>(Baz)</a>.