### PR TITLE
ci: add missing GHA permission for private repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      contents: read
       id-token: write # for npm to create release with provenance
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
# Generated description
Add the <code>contents: read</code> permission to the GitHub Actions release workflow (<code>release.yml</code>) to ensure proper access for operations within a private repository.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>feat-add-release-pleas...</td><td>November 05, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/13?tool=ast>(Baz)</a>.