### PR TITLE
fix: disable provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Publish release to npm
-        run: npm publish --provenance --access public
+        # `provenance` can only be on public repos
+        # https://github.blog/changelog/2023-07-25-publishing-with-npm-provenance-from-private-source-repositories-is-no-longer-supported/
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Generated description
Updates the <code>npm publish</code> command in the GitHub Actions release workflow to remove the <code>--provenance</code> flag, resolving an issue where publishing from private source repositories with provenance is no longer supported.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>test-add-a-build-test-...</td><td>November 06, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/17?tool=ast>(Baz)</a>.