### PR TITLE
fix: fix CLI version bump

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [
-        "README.md"
+        "README.md",
+        "src/index.ts"
       ],
       "changelog-sections": [
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,11 @@ import React from "react";
 import ReviewFlow from "./flows/Review.js";
 import { createAuthCommand } from "./commands/auth.js";
 
+const VERSION = "0.1.3";
+
 const program = new Command();
 
-program.name("Baz CLI").version("0.1.0");
+program.name("Baz CLI").version(VERSION);
 
 program
   .command("review")


### PR DESCRIPTION
# Generated description
Updates the CLI's versioning mechanism to use a constant, allowing the <code>release-please</code> tool to automatically bump the version in <code>src/index.ts</code>. Configures <code>release-please</code> to track <code>src/index.ts</code> for version updates.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>feat-add-release-pleas...</td><td>November 05, 2025</td></tr>
<tr><td>yuvalyacoby</td><td>CR-2519-oauth-flow-1</td><td>October 05, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/21?tool=ast>(Baz)</a>.