### PR TITLE
feat: change package name to @baz-scm/cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@baz-scm/baz-cli",
+  "name": "@baz-scm/cli",
   "version": "0.1.3",
   "description": "Baz CLI tool for managing pull requests",
   "main": "dist/index.js",


### PR DESCRIPTION
# Generated description
Renames the package name from <code>@baz-scm/baz-cli</code> to <code>@baz-scm/cli</code> within the <code>package.json</code> file. Updates the primary identifier for the Baz CLI tool.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>internal-baz-ci-app[bot]</td><td>chore-main-release-0.1...</td><td>November 06, 2025</td></tr>
<tr><td>anton.gruebel@gmail.com</td><td>feat-add-release-pleas...</td><td>November 05, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/23?tool=ast>(Baz)</a>.