### PR TITLE
ci: set up trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
-      contents: read
-      id-token: write # for npm to create release with provenance
+      contents: read # this permission is mandatory for checking out private repos
+      id-token: write # this permission is mandatory for trusted publishing to npmjs
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
@@ -51,8 +51,8 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Publish release to npm
-        # `provenance` can only be on public repos
-        # https://github.blog/changelog/2023-07-25-publishing-with-npm-provenance-from-private-source-repositories-is-no-longer-supported/
-        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # `provenance` can only be enabled on public repos
+          # https://github.blog/changelog/2023-07-25-publishing-with-npm-provenance-from-private-source-repositories-is-no-longer-supported/
+          NPM_CONFIG_PROVENANCE: false
+        run: npm publish --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: "https://registry.npmjs.org"
       # ensure npm 11.5.1+ is installed for trusted publishing
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@^11.5.1
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           registry-url: "https://registry.npmjs.org"
+      # ensure npm 11.5.1+ is installed for trusted publishing
+      - run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
       - name: Build project


### PR DESCRIPTION
# Generated description
Update the GitHub Actions release workflow (<code>release.yml</code>) to enable trusted publishing to npmjs. Configure necessary permissions and ensure the correct npm version for publication.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>fix-disable-provenance-17</td><td>November 06, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/25?tool=ast>(Baz)</a>.