### PR TITLE
feat: CR-2812 align to new spec review response

### DIFF
--- a/src/components/PullRequestOverview.tsx
+++ b/src/components/PullRequestOverview.tsx
@@ -78,10 +78,10 @@ const SpecReviewSummary: React.FC<{
   let specReviewSummary = "No requirements were identified";
   const latestSpecReview = specReviews.at(-1);
   if (
-    latestSpecReview?.result &&
-    latestSpecReview.result.requirements_found > 0
+    latestSpecReview?.requirementsFound &&
+    latestSpecReview.requirementsFound > 0
   ) {
-    specReviewSummary = `${latestSpecReview.result.requirements_met}/${latestSpecReview.result.requirements_found} met requirements in this CR`;
+    specReviewSummary = `${latestSpecReview.requirementsMet}/${latestSpecReview.requirementsFound} met requirements in this CR`;
   }
 
   return (

--- a/src/components/PullRequestReview.tsx
+++ b/src/components/PullRequestReview.tsx
@@ -82,17 +82,16 @@ const PullRequestReview: React.FC<PullRequestReviewProps> = ({
     metRequirements: Requirement[];
   } => {
     const latestSpecReview = specReviews.data.at(-1);
-    const result = latestSpecReview?.result;
 
-    if (!result) {
+    if (!latestSpecReview) {
       return { unmetRequirements: [], metRequirements: [] };
     }
 
     return {
-      unmetRequirements: result.requirements.filter(
+      unmetRequirements: latestSpecReview.requirements.filter(
         (req) => req.verdict !== "met",
       ),
-      metRequirements: result.requirements.filter(
+      metRequirements: latestSpecReview.requirements.filter(
         (req) => req.verdict === "met",
       ),
     };
@@ -125,8 +124,7 @@ const PullRequestReview: React.FC<PullRequestReviewProps> = ({
       return;
     }
 
-    const result = latestSpecReview.result;
-    if (!result) {
+    if (!latestSpecReview) {
       setState({ step: "triggerSpecReview" });
       return;
     }

--- a/src/lib/clients/baz.ts
+++ b/src/lib/clients/baz.ts
@@ -187,7 +187,9 @@ export interface SpecReview {
   id: string;
   commitSha: string;
   status: "success" | "failed" | "in_progress" | "user_canceled";
-  result?: SpecReviewResult;
+  requirementsFound: number;
+  requirementsMet: number;
+  requirements: Requirement[];
   commentId: string;
   createdAt: string;
   checkRunId: string;
@@ -210,19 +212,7 @@ export interface Requirement {
 export type Verdict = "met" | "partially met" | "not met";
 
 export interface SpecReviewsResponse {
-  specReviews: SpecReviewAPIResponse[];
-}
-
-export interface SpecReviewAPIResponse {
-  id: string;
-  prId: string;
-  commitSha: string;
-  previewEnvUrl?: string;
-  status: "success" | "failed" | "in_progress" | "user_canceled";
-  result?: SpecReviewResult;
-  commentId: string;
-  createdAt: string;
-  checkRunId: string;
+  specReviews: SpecReview[];
 }
 
 export async function fetchPRDetails(


### PR DESCRIPTION
# Generated description
```mermaid
graph LR
PullRequestReview_getRequirementsData_("PullRequestReview.getRequirementsData"):::modified
SpecReview_("SpecReview"):::modified
PullRequestReview_handlePrOverviewContinue_("PullRequestReview.handlePrOverviewContinue"):::modified
SpecReviewSummary_("SpecReviewSummary"):::modified
PullRequestReview_getRequirementsData_ -- "Replaced nested result with direct requirements fields." --> SpecReview_
PullRequestReview_handlePrOverviewContinue_ -- "Checks latestSpecReview existence before proceeding." --> PullRequestReview_getRequirementsData_
SpecReviewSummary_ -- "Updated summary to use new requirements count fields." --> SpecReview_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Align the <code>SpecReview</code> data structure with a new formalized backend response, promoting <code>requirementsFound</code>, <code>requirementsMet</code>, and <code>requirements</code> directly onto the <code>SpecReview</code> interface. Update frontend components, such as <code>PullRequestOverview</code> and <code>PullRequestReview</code>, to consume this flattened data structure.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>feat-CR-2814-menu-and-...</td><td>November 27, 2025</td></tr>
<tr><td>nimrod@baz.co</td><td>feat-Skip-repo-selecti...</td><td>November 24, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/49?tool=ast>(Baz)</a>.