### PR TITLE
fix: Add error message for insufficient write access

### DIFF
--- a/src/components/PullRequestReview.tsx
+++ b/src/components/PullRequestReview.tsx
@@ -18,6 +18,7 @@ import { MAIN_COLOR } from "../theme/colors.js";
 import { useAppMode } from "../lib/config/AppModeContext.js";
 import type { Requirement } from "../lib/providers/index.js";
 import { PRContext } from "../lib/providers/index.js";
+import { useRepoWriteAccess } from "../hooks/useRepoWriteAccess.js";
 
 interface MenuStateData {
   unmetRequirements: Requirement[];
@@ -52,14 +53,20 @@ const PullRequestReview: React.FC<PullRequestReviewProps> = ({
   const pr = usePullRequest(prContext);
   const issues = useIssues(prContext);
   const specReviews = useSpecReviews(prContext.prId);
+  const repoWriteAccess = useRepoWriteAccess(prContext);
 
   const prId = prContext.prId;
   const fullRepoName = prContext.fullRepoName;
   // bazRepoId is only available in baz mode, undefined in tokens mode
   const bazRepoId = pr.data?.repository_id;
 
-  const loading = pr.loading || issues.loading || specReviews.loading;
-  const error = pr.error || issues.error || specReviews.error;
+  const loading =
+    pr.loading ||
+    issues.loading ||
+    specReviews.loading ||
+    repoWriteAccess.loading;
+  const error =
+    pr.error || issues.error || specReviews.error || repoWriteAccess.error;
 
   if (loading) {
     return (
@@ -390,6 +397,7 @@ const PullRequestReview: React.FC<PullRequestReviewProps> = ({
           bazRepoId={bazRepoId}
           fullRepoName={fullRepoName}
           prNumber={prContext.prNumber}
+          writeAccess={repoWriteAccess.data}
           onComplete={handleIssuesComplete}
           onBack={handleBackFromIssues}
         />

--- a/src/hooks/useRepoWriteAccess.ts
+++ b/src/hooks/useRepoWriteAccess.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+import {
+  type PRContext,
+  RepoWriteAccess,
+  RepoWriteAccessReason,
+} from "../lib/providers/index.js";
+import { useAppMode } from "../lib/config/AppModeContext.js";
+
+export function useRepoWriteAccess(ctx: PRContext) {
+  const [data, setData] = useState<RepoWriteAccess>({
+    hasAccess: false,
+    reason: RepoWriteAccessReason.MISSING_USER_INSTALLATION,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const appMode = useAppMode();
+
+  useEffect(() => {
+    appMode.mode.dataProvider
+      .fetchRepoWriteAccess(ctx)
+      .then((access) => {
+        setData(access);
+      })
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { data, loading, error };
+}

--- a/src/issues/discussion/DiscussionIssueHandler.tsx
+++ b/src/issues/discussion/DiscussionIssueHandler.tsx
@@ -94,7 +94,7 @@ export const discussionIssueHandler: IssueTypeHandler<
               return {
                 shouldMoveNext: false,
                 shouldComplete: false,
-                errorMessages: commentErrorMessage(access.reason),
+                errorMessage: commentErrorMessage(access.reason),
               };
             } else {
               context.setRepoWriteAccess(access);
@@ -157,6 +157,6 @@ function commentErrorMessage(reason: RepoWriteAccessReason | null) {
         `${env.BAZ_BASE_URL}/settings/integrations/github`
       );
     default:
-      return undefined;
+      return `Unknown error: ${reason}`;
   }
 }

--- a/src/issues/discussion/DiscussionIssueHandler.tsx
+++ b/src/issues/discussion/DiscussionIssueHandler.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Issue, IssueTypeHandler, IssueCommand } from "../types.js";
 import DiscussionIssueDisplay from "./DiscussionIssueDisplay.js";
 import {
+  fetchRepoWriteAccess,
   postDiscussionReply,
   updateDiscussionState,
 } from "../../lib/clients/baz.js";
@@ -10,6 +11,8 @@ import { parseHtmlToMarkdown } from "../../lib/parser.js";
 import { Box, Text } from "ink";
 import { IssueType } from "../../models/chat.js";
 import { renderMarkdown } from "../../lib/markdown.js";
+import { RepoWriteAccessReason } from "../../lib/providers/index.js";
+import { env } from "../../lib/env-schema.js";
 
 export const discussionIssueHandler: IssueTypeHandler<
   Issue & { type: "discussion" }
@@ -80,6 +83,18 @@ export const discussionIssueHandler: IssueTypeHandler<
           return {};
         }
         try {
+          if (!context.repoWriteAccess.hasAccess) {
+            const access = await fetchRepoWriteAccess(context.fullRepoName);
+            if (!access.hasAccess) {
+              return {
+                shouldMoveNext: false,
+                shouldComplete: false,
+                errorMessages: commentErrorMessage(access.reason),
+              };
+            } else {
+              context.setRepoWriteAccess(access);
+            }
+          }
           await postDiscussionReply(issue.data.id, args, context.prId);
           return {
             shouldMoveNext: context.hasNext,
@@ -118,3 +133,21 @@ export const discussionIssueHandler: IssueTypeHandler<
     return IssueType.DISCUSSION;
   },
 };
+
+function commentErrorMessage(reason: RepoWriteAccessReason | null) {
+  switch (reason) {
+    case RepoWriteAccessReason.MISSING_USER_INSTALLATION:
+      return (
+        "Write access is required to post comments. Please grant access in Baz.\n" +
+        `${env.BAZ_BASE_URL}/privilege`
+      );
+    case RepoWriteAccessReason.MISSING_ORG_INSTALLATION:
+    case RepoWriteAccessReason.REPO_NOT_CONFIGURED:
+      return (
+        "Baz needs write access at the organization level. Please ask your GitHub admin to grant this permission.\n" +
+        `${env.BAZ_BASE_URL}/settings/integrations/github`
+      );
+    default:
+      return undefined;
+  }
+}

--- a/src/issues/types.ts
+++ b/src/issues/types.ts
@@ -1,4 +1,4 @@
-import type { Discussion } from "../lib/providers/index.js";
+import type { Discussion, RepoWriteAccess } from "../lib/providers/index.js";
 import { IssueType } from "../models/chat.js";
 
 export type Issue = {
@@ -22,15 +22,18 @@ export interface IssueContext {
   totalIssues: number;
   hasNext: boolean;
   conversationId?: string;
+  repoWriteAccess: RepoWriteAccess;
   moveToNext: () => void;
   complete: () => void;
   setConversationId: (id: string) => void;
+  setRepoWriteAccess: (writeAccess: RepoWriteAccess) => void;
   onChatSubmit: (message: string) => Promise<void>;
 }
 
 export interface CommandResult {
   shouldMoveNext?: boolean;
   shouldComplete?: boolean;
+  errorMessage?: string;
 }
 
 export interface IssueTypeHandler<T extends Issue = Issue> {

--- a/src/issues/types.ts
+++ b/src/issues/types.ts
@@ -1,5 +1,6 @@
 import type { Discussion, RepoWriteAccess } from "../lib/providers/index.js";
 import { IssueType } from "../models/chat.js";
+import { AppConfig } from "../lib/config/index.js";
 
 export type Issue = {
   type: "discussion";
@@ -23,6 +24,7 @@ export interface IssueContext {
   hasNext: boolean;
   conversationId?: string;
   repoWriteAccess: RepoWriteAccess;
+  appMode: AppConfig;
   moveToNext: () => void;
   complete: () => void;
   setConversationId: (id: string) => void;

--- a/src/lib/clients/baz.ts
+++ b/src/lib/clients/baz.ts
@@ -408,7 +408,7 @@ export async function fetchRepoWriteAccess(
     })
     .then((value) => value.data)
     .catch((error: unknown) => {
-      logger.debug(`Axios error while resolving discussion: ${error}`);
+      logger.debug(`Axios error while fetching repo write access: ${error}`);
       throw error;
     });
 

--- a/src/lib/clients/baz.ts
+++ b/src/lib/clients/baz.ts
@@ -6,17 +6,18 @@ import {
   ChatStreamMessage,
   CheckoutChatRequest,
 } from "../../models/chat.js";
-import type {
+import {
+  ChangeReviewer,
+  Discussion,
+  FileDiff,
   Integration,
   IntegrationType,
+  MergeStatus,
   PullRequest,
   PullRequestDetails,
-  Discussion,
-  SpecReview,
+  RepoWriteAccess,
   Requirement,
-  ChangeReviewer,
-  MergeStatus,
-  FileDiff,
+  SpecReview,
 } from "../providers/types.js";
 
 const COMMENTS_URL = `${env.BAZ_BASE_URL}/api/v1/comments`;
@@ -44,6 +45,8 @@ const getApprovalUrl = (prId: string) =>
 
 const getMergeUrl = (prId: string) =>
   `${env.BAZ_BASE_URL}/api/v2/changes/${prId}/merge`;
+const getRepoWriteAccessUrl = (fullRepoName: string) =>
+  `${env.BAZ_BASE_URL}/api/v2/installations/write-access/${encodeURIComponent(fullRepoName)}`;
 
 const axiosClient = createAxiosClient(env.BAZ_BASE_URL);
 
@@ -392,6 +395,24 @@ export async function fetchFileDiffs(
     });
 
   return repos.fileDiffs;
+}
+
+export async function fetchRepoWriteAccess(
+  fullRepoName: string,
+): Promise<RepoWriteAccess> {
+  const resp = await axiosClient
+    .get<RepoWriteAccess>(getRepoWriteAccessUrl(fullRepoName), {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+    .then((value) => value.data)
+    .catch((error: unknown) => {
+      logger.debug(`Axios error while resolving discussion: ${error}`);
+      throw error;
+    });
+
+  return resp;
 }
 
 function* processStreamMessage(

--- a/src/lib/clients/github.ts
+++ b/src/lib/clients/github.ts
@@ -308,6 +308,34 @@ export async function fetchUnresolvedReviewThreads(
   }
 }
 
+export async function postReviewThreadReply(
+  fullRepoName: string,
+  prNumber: number,
+  threadId: string,
+  body: string,
+) {
+  const octokit = getOctokitClient();
+  const { owner, repo } = parseRepoId(fullRepoName);
+
+  try {
+    await octokit.rest.pulls.createReviewComment({
+      owner,
+      repo,
+      pull_number: prNumber,
+      body,
+      in_reply_to: Number(threadId),
+      commit_id: "", // values are required but ignored
+      path: "", // values are required but ignored
+    });
+  } catch (error) {
+    logger.error(
+      { error, fullRepoName, prNumber },
+      "Error replying to review comment on GitHub",
+    );
+    throw error;
+  }
+}
+
 export async function approvePullRequest(
   fullRepoName: string,
   prNumber: number,

--- a/src/lib/providers/baz-provider.ts
+++ b/src/lib/providers/baz-provider.ts
@@ -11,6 +11,7 @@ import {
   fetchFileDiffs as bazFetchFileDiffs,
   fetchEligibleReviewers as bazFetchEligibleReviewers,
   fetchRepoWriteAccess as bazFetchRepoWriteAccess,
+  postDiscussionReply as bazPostDiscussionReply,
 } from "../clients/baz.js";
 import type {
   PRContext,
@@ -46,6 +47,14 @@ export class BazDataProvider implements IDataProvider {
 
   async fetchDiscussions(ctx: PRContext): Promise<Discussion[]> {
     return bazFetchDiscussions(ctx.prId);
+  }
+
+  async postDiscussionReply(
+    ctx: PRContext,
+    discussionId: string,
+    body: string,
+  ): Promise<void> {
+    await bazPostDiscussionReply(discussionId, body, ctx.prId);
   }
 
   async approvePR(ctx: PRContext): Promise<void> {

--- a/src/lib/providers/baz-provider.ts
+++ b/src/lib/providers/baz-provider.ts
@@ -10,6 +10,7 @@ import {
   fetchUser as bazFetchUser,
   fetchFileDiffs as bazFetchFileDiffs,
   fetchEligibleReviewers as bazFetchEligibleReviewers,
+  fetchRepoWriteAccess as bazFetchRepoWriteAccess,
 } from "../clients/baz.js";
 import type {
   PRContext,
@@ -22,6 +23,7 @@ import type {
   User,
   FileDiff,
   ChangeReviewer,
+  RepoWriteAccess,
 } from "./types.js";
 import { IDataProvider } from "./data-provider.js";
 
@@ -76,5 +78,9 @@ export class BazDataProvider implements IDataProvider {
 
   async fetchEligibleReviewers(ctx: PRContext): Promise<ChangeReviewer[]> {
     return bazFetchEligibleReviewers(ctx.prId);
+  }
+
+  async fetchRepoWriteAccess(ctx: PRContext): Promise<RepoWriteAccess> {
+    return bazFetchRepoWriteAccess(ctx.fullRepoName);
   }
 }

--- a/src/lib/providers/data-provider.ts
+++ b/src/lib/providers/data-provider.ts
@@ -9,6 +9,7 @@ import type {
   FileDiff,
   ChangeReviewer,
   PRContext,
+  RepoWriteAccess,
 } from "./types.js";
 
 export interface IDataProvider {
@@ -37,4 +38,6 @@ export interface IDataProvider {
   ): Promise<FileDiff[]>;
 
   fetchEligibleReviewers(ctx: PRContext): Promise<ChangeReviewer[]>;
+
+  fetchRepoWriteAccess(ctx: PRContext): Promise<RepoWriteAccess>;
 }

--- a/src/lib/providers/data-provider.ts
+++ b/src/lib/providers/data-provider.ts
@@ -23,6 +23,12 @@ export interface IDataProvider {
 
   fetchDiscussions(ctx: PRContext): Promise<Discussion[]>;
 
+  postDiscussionReply(
+    ctx: PRContext,
+    discussionId: string,
+    body: string,
+  ): Promise<void>;
+
   approvePR(ctx: PRContext): Promise<void>;
 
   mergePR(ctx: PRContext): Promise<void>;

--- a/src/lib/providers/tokens-provider.ts
+++ b/src/lib/providers/tokens-provider.ts
@@ -21,6 +21,7 @@ import {
   fetchAuthenticatedUser,
   fetchFileDiffs as ghFetchFileDiffs,
   fetchAssignees,
+  postReviewThreadReply,
 } from "../clients/github.js";
 
 export class TokensDataProvider implements IDataProvider {
@@ -98,6 +99,19 @@ export class TokensDataProvider implements IDataProvider {
         })),
       };
     });
+  }
+
+  async postDiscussionReply(
+    ctx: PRContext,
+    discussionId: string,
+    body: string,
+  ): Promise<void> {
+    await postReviewThreadReply(
+      ctx.fullRepoName,
+      ctx.prNumber,
+      discussionId,
+      body,
+    );
   }
 
   async approvePR(ctx: PRContext): Promise<void> {

--- a/src/lib/providers/tokens-provider.ts
+++ b/src/lib/providers/tokens-provider.ts
@@ -9,6 +9,7 @@ import type {
   User,
   FileDiff,
   ChangeReviewer,
+  RepoWriteAccess,
 } from "./types.js";
 import {
   fetchOpenPullRequests,
@@ -139,5 +140,14 @@ export class TokensDataProvider implements IDataProvider {
       login: assignee.login,
       avatar_url: assignee.avatar_url,
     }));
+  }
+
+  async fetchRepoWriteAccess(_ctx: PRContext): Promise<RepoWriteAccess> {
+    // if the user uses a fine-grained PAT, then we can't determine repo access therefore,
+    // let's assume we have it and fail on writing
+    return {
+      hasAccess: true,
+      reason: null,
+    };
   }
 }

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -142,3 +142,14 @@ export interface PRContext {
   fullRepoName: string;
   prNumber: number;
 }
+
+export enum RepoWriteAccessReason {
+  MISSING_USER_INSTALLATION = "missing-user-installation",
+  MISSING_ORG_INSTALLATION = "missing-org-installation",
+  REPO_NOT_CONFIGURED = "repo-not-configured",
+}
+
+export interface RepoWriteAccess {
+  hasAccess: boolean;
+  reason: RepoWriteAccessReason | null;
+}

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -113,7 +113,7 @@ export interface ChatToolCall {
 }
 
 export interface ChatMessage {
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "error";
   content: string;
   toolCalls?: ChatToolCall[];
 }

--- a/src/pages/IssueBrowser.tsx
+++ b/src/pages/IssueBrowser.tsx
@@ -6,6 +6,7 @@ import ChatDisplay from "./chat/ChatDisplay.js";
 import { ChatMessage } from "../models/chat.js";
 import { streamChatResponse } from "../lib/clients/baz.js";
 import { RepoWriteAccess } from "../lib/providers/index.js";
+import { useAppMode } from "../lib/config/index.js";
 
 interface IssueBrowserProps {
   issues: Issue[];
@@ -36,6 +37,7 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
   const [repoWriteAccess, setRepoWriteAccess] =
     useState<RepoWriteAccess>(writeAccess);
   const [isLoading, setIsLoading] = useState(false);
+  const appMode = useAppMode();
 
   const currentIssue = issues[currentIndex];
   const hasNext = currentIndex < issues.length - 1;
@@ -125,6 +127,7 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
       hasNext,
       conversationId,
       repoWriteAccess,
+      appMode,
       moveToNext: () => {
         if (hasNext) {
           setCurrentIndex((prev) => prev + 1);
@@ -148,6 +151,7 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
       hasNext,
       conversationId,
       repoWriteAccess,
+      appMode,
       onComplete,
       handleChatSubmit,
     ],

--- a/src/pages/chat/ChatDisplay.tsx
+++ b/src/pages/chat/ChatDisplay.tsx
@@ -7,6 +7,29 @@ import { renderMarkdown } from "../../lib/markdown.js";
 import ChatInput from "./ChatInput.js";
 import ToolCallDisplay from "./ToolCallDisplay.js";
 
+const MemoizedMessageAuthor = memo(({ message }: { message: ChatMessage }) => {
+  switch (message.role) {
+    case "user":
+      return (
+        <Text bold color="cyan">
+          You:
+        </Text>
+      );
+    case "assistant":
+      return (
+        <Text bold color="yellow">
+          Baz:
+        </Text>
+      );
+    case "error":
+      return (
+        <Text bold color="red">
+          Error:
+        </Text>
+      );
+  }
+});
+
 interface MemoizedMessageProps {
   message: ChatMessage;
   isToolExpanded: boolean;
@@ -22,9 +45,7 @@ const MemoizedMessage = memo<MemoizedMessageProps>(
 
     return (
       <Box flexDirection="column" marginBottom={1}>
-        <Text bold color={message.role === "user" ? "cyan" : "yellow"}>
-          {message.role === "user" ? "You:" : "Baz:"}
-        </Text>
+        <MemoizedMessageAuthor message={message} />
         <Box paddingLeft={2} flexDirection="column">
           {message.toolCalls && message.toolCalls.length > 0 && (
             <Box flexDirection="column">


### PR DESCRIPTION
# Generated description
Implement a new <code>useRepoWriteAccess</code> hook to check for repository write access, preventing users from posting comments if they lack the necessary permissions. Display specific error messages within the chat interface, guiding users on how to resolve access issues.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/64?tool=ast>(Baz)</a>.