### PR TITLE
feat: replace ctrl with tab

### DIFF
--- a/src/pages/chat/ChatInput.tsx
+++ b/src/pages/chat/ChatInput.tsx
@@ -49,9 +49,6 @@ const ChatInput = memo<ChatInputProps>(
     const inputValueRef = useRef(inputValue);
     inputValueRef.current = inputValue;
 
-    // Track when a Ctrl shortcut was pressed to skip the character in TextInput
-    const skipNextInputRef = useRef(false);
-
     useEffect(() => {
       if (enableMentions && prId && fullRepoName && prNumber !== undefined) {
         dataProvider
@@ -63,9 +60,9 @@ const ChatInput = memo<ChatInputProps>(
       }
     }, [enableMentions, prId, fullRepoName, prNumber]);
 
-    // Only handle escape key in useInput - let TextInput handle all other input
+    // Handle special keys - let TextInput handle regular text input
     useInput(
-      (input, key) => {
+      (_input, key) => {
         if (key.escape) {
           if (showMentionAutocomplete) {
             setShowMentionAutocomplete(false);
@@ -74,8 +71,8 @@ const ChatInput = memo<ChatInputProps>(
           } else {
             onBack();
           }
-        } else if (toolsExist && key.ctrl && input.toLowerCase() === "o") {
-          skipNextInputRef.current = true; // Skip the "o" that TextInput will add
+        } else if (key.tab && toolsExist) {
+          // Tab toggles tool call expansion
           onToggleToolCallExpansion();
         }
       },
@@ -83,12 +80,6 @@ const ChatInput = memo<ChatInputProps>(
     );
 
     const handleInputChange = (value: string) => {
-      // Skip input if a Ctrl shortcut was just pressed (e.g., Ctrl+O adds stray "o")
-      if (skipNextInputRef.current) {
-        skipNextInputRef.current = false;
-        return;
-      }
-
       // Handle "?" for help toggle when input is empty
       if (inputValueRef.current === "" && value === "?") {
         setShowFullHelp((prev) => !prev);

--- a/src/pages/chat/ToolCallDisplay.tsx
+++ b/src/pages/chat/ToolCallDisplay.tsx
@@ -70,7 +70,7 @@ const ToolCallDisplay = memo<ToolCallDisplayProps>(
               {!isExpanded && showExpandHint && (
                 <Text dimColor italic>
                   {" "}
-                  - Press Ctrl+O to expand
+                  - Press Tab to expand
                 </Text>
               )}
             </>


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the chat input component to use the <code>Tab</code> key for toggling tool call expansion, replacing the previous <code>Ctrl+O</code> shortcut. Modify the <code>ToolCallDisplay</code> component to reflect this new keyboard shortcut hint.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>feat-Full-pr-data-impl...</td><td>December 09, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/70?tool=ast>(Baz)</a>.