### PR TITLE
docs: Improve GH PAT permissions documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ baz
 ### Requirements
 
 - **Node.js** 22 or later (see `engines` in `package.json`)
-- **Standalone Mode**: GitHub PAT and Anthropic API key
+- **Standalone Mode**: GitHub PAT and Anthropic token. For GitHub, make sure your fine-grained personal access token has the following scopes:
+  - Contents - `Read and write` - to allow merging PRs and resolving comments. If you only want to review and approve, `Read` is enough.
+  - Pull Requests - `Read and write` - to allow creating comments and approving the PR. If you only want to read PR content, `Read` is enough.
 - **Integrated Mode**: Account in [Baz](https://baz.co/login)
 - **Optional**: Jira, Linear, YouTrack, etc. integrated in baz for ticket context
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Baz CLI offers two modes to fit your workflow:
 
 ### 🔑 Standalone Mode (Bring your own keys)
 
-Use your own GitHub Personal Access Token (PAT) and Anthropic API key to review any pull request directly.
+Use your own GitHub Personal Access Token (PAT) and Anthropic token to review any pull request directly.
 
 **Perfect for:**
 - Reviewing PRs without Baz service integration


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhance the project's <code>README.md</code> by detailing the required GitHub Personal Access Token (PAT) permissions for standalone mode, specifying <code>Contents</code> and <code>Pull Requests</code> scopes. Update the documentation to consistently refer to the <code>Anthropic token</code>.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrod@baz.co</td><td>docs-README-update-and...</td><td>December 15, 2025</td></tr>
<tr><td>guyeisenkot</td><td>docs-Enhance-README-wi...</td><td>December 04, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/75?tool=ast>(Baz)</a>.