### PR TITLE
fix: implement resolve and comment

### DIFF
--- a/src/issues/discussion/DiscussionIssueHandler.tsx
+++ b/src/issues/discussion/DiscussionIssueHandler.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Issue, IssueTypeHandler, IssueCommand } from "../types.js";
 import DiscussionIssueDisplay from "./DiscussionIssueDisplay.js";
-import { updateDiscussionState } from "../../lib/clients/baz.js";
 import IssueExplanationDisplay from "../common/IssueExplanationDisplay.js";
 import { parseHtmlToMarkdown } from "../../lib/parser.js";
 import { Box, Text } from "ink";
@@ -116,7 +115,10 @@ export const discussionIssueHandler: IssueTypeHandler<
 
       case "resolve":
         try {
-          await updateDiscussionState(issue.data.id);
+          await context.appMode.mode.dataProvider.resolveDiscussion(
+            prContext,
+            issue.data.id,
+          );
           return {
             shouldMoveNext: context.hasNext,
             shouldComplete: !context.hasNext,

--- a/src/lib/providers/baz-provider.ts
+++ b/src/lib/providers/baz-provider.ts
@@ -12,6 +12,7 @@ import {
   fetchEligibleReviewers as bazFetchEligibleReviewers,
   fetchRepoWriteAccess as bazFetchRepoWriteAccess,
   postDiscussionReply as bazPostDiscussionReply,
+  updateDiscussionState as bazUpdateDiscussionState,
 } from "../clients/baz.js";
 import type {
   PRContext,
@@ -56,6 +57,13 @@ export class BazDataProvider implements IDataProvider {
     body: string,
   ): Promise<void> {
     await bazPostDiscussionReply(discussionId, body, ctx.prId);
+  }
+
+  async resolveDiscussion(
+    _ctx: PRContext,
+    discussionId: string,
+  ): Promise<void> {
+    await bazUpdateDiscussionState(discussionId);
   }
 
   async approvePR(ctx: PRContext): Promise<void> {

--- a/src/lib/providers/data-provider.ts
+++ b/src/lib/providers/data-provider.ts
@@ -30,6 +30,8 @@ export interface IDataProvider {
     body: string,
   ): Promise<void>;
 
+  resolveDiscussion(ctx: PRContext, discussionId: string): Promise<void>;
+
   approvePR(ctx: PRContext): Promise<void>;
 
   mergePR(ctx: PRContext, mergeStrategy: MergeMethod): Promise<void>;

--- a/src/lib/providers/tokens-provider.ts
+++ b/src/lib/providers/tokens-provider.ts
@@ -23,6 +23,7 @@ import {
   fetchFileDiffs as ghFetchFileDiffs,
   fetchAssignees,
   postReviewThreadReply,
+  resolveReviewThread,
 } from "../clients/github.js";
 
 export class TokensDataProvider implements IDataProvider {
@@ -113,6 +114,10 @@ export class TokensDataProvider implements IDataProvider {
       discussionId,
       body,
     );
+  }
+
+  async resolveDiscussion(ctx: PRContext, discussionId: string): Promise<void> {
+    await resolveReviewThread(ctx.fullRepoName, discussionId);
   }
 
   async approvePR(ctx: PRContext): Promise<void> {


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
TokensDataProvider_resolveDiscussion_("TokensDataProvider.resolveDiscussion"):::added
resolveReviewThread_("resolveReviewThread"):::added
BazDataProvider_resolveDiscussion_("BazDataProvider.resolveDiscussion"):::added
bazUpdateDiscussionState_("bazUpdateDiscussionState"):::added
handleCommand_("handleCommand"):::modified
IDataProvider_resolveDiscussion_("IDataProvider.resolveDiscussion"):::added
postReviewThreadReply_("postReviewThreadReply"):::modified
fetchReviewThreadFirstCommentDatabaseId_("fetchReviewThreadFirstCommentDatabaseId"):::added
TokensDataProvider_resolveDiscussion_ -- "Marks GitHub review thread resolved using repo and thread ID." --> resolveReviewThread_
BazDataProvider_resolveDiscussion_ -- "Updates discussion state in Baz system via external service." --> bazUpdateDiscussionState_
handleCommand_ -- "Resolves discussion issues via current data provider method." --> IDataProvider_resolveDiscussion_
handleCommand_ -- "Resolves discussion using TokensDataProvider's resolveDiscussion method." --> TokensDataProvider_resolveDiscussion_
postReviewThreadReply_ -- "Fetches first comment database ID before posting review reply." --> fetchReviewThreadFirstCommentDatabaseId_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Implement the ability to resolve discussion threads through the <code>IDataProvider</code> interface, allowing both Baz and GitHub providers to handle this action. Refactor the GitHub client to use GraphQL for resolving review threads and enhance the comment reply mechanism by correctly identifying the target comment's database ID.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/79?tool=ast&topic=Resolve+Discussions>Resolve Discussions</a>
        </td><td>Implement the <code>resolveDiscussion</code> method across data providers to allow users to mark discussion threads as resolved.<details><summary>Modified files (5)</summary><ul><li>src/lib/clients/github.ts</li>
<li>src/lib/providers/tokens-provider.ts</li>
<li>src/issues/discussion/DiscussionIssueHandler.tsx</li>
<li>src/lib/providers/baz-provider.ts</li>
<li>src/lib/providers/data-provider.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>fix-fix-merge-actions-77</td><td>December 15, 2025</td></tr>
<tr><td>anton.gruebel@gmail.com</td><td>fix-Add-error-message-...</td><td>December 11, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/79?tool=ast&topic=Enhance+Comment+Replies>Enhance Comment Replies</a>
        </td><td>Improve the GitHub comment reply functionality by fetching the first comment's database ID to accurately target replies.<details><summary>Modified files (1)</summary><ul><li>src/lib/clients/github.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>fix-fix-merge-actions-77</td><td>December 15, 2025</td></tr>
<tr><td>anton.gruebel@gmail.com</td><td>fix-Add-error-message-...</td><td>December 11, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/79?tool=ast>(Baz)</a>.