### PR TITLE
feat: Clarify instrctl LLM wiring and gaps CR-2997 

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,25 @@ npm install
 | `npm run format:check` | Verify source files with Prettier |
 | `npm run format:fix` | Format source files with Prettier |
 
+### Instruction document sync with `instrctl`
+
+The CLI now ships with an experimental `instrctl` command group that mirrors the execution design in `docs/instrctl-execution-spec.md`:
+
+- `baz instrctl init` — scans the repository for instruction documents (CLAUDE, agents, cursor rules, etc.), extracts principles, and writes `.instrctl/state.json` plus conflict reports.
+- `baz instrctl plan` — compares the desired principles (from `.instrctl/instrctl.hcl` when present) with discovered documents and produces `.instrctl/plan.json` alongside unified diffs to inject a managed principles section.
+- `baz instrctl apply` — applies the generated plan using `git apply`, letting you iterate on instruction alignment without touching source files.
+
+instrctl will opportunistically call an Anthropic LLM for principle extraction when `ANTHROPIC_TOKEN` is set (or provided through Baz tokens mode) and silently fall back to the deterministic parser when unavailable.
+
+Managed sections are appended with the heading `## Managed Principles` and fenced with `<!-- instrctl:begin managed -->`/`<!-- instrctl:end managed -->` markers to keep edits deterministic.
+
+> ⚠️ Current instrctl limitations
+>
+> - LLM usage is extraction-only. Plan/apply does not yet enforce patch bounding, PR creation, or override semantics from the execution spec.
+> - Git automation is minimal: `instrctl apply` simply runs `git apply` against generated diffs and expects you to commit/PR changes yourself.
+> - Tokens: Anthropic keys are read from `ANTHROPIC_TOKEN`, `BAZ_LLM_TOKEN`, or `BAZ_TOKEN`. If none are set, instrctl always falls back to the heuristic parser.
+> - State/config drift detection is basic. The plan currently rewrites the managed section wholesale and does not honor `.instrctl/instrctl.hcl` deletes or overrides.
+
 ### Development Workflow
 
 1. Create a `.env` file with your local configuration

--- a/docs/instrctl-execution-spec.md
+++ b/docs/instrctl-execution-spec.md
@@ -1,0 +1,880 @@
+# instrctl Execution Specification
+
+**A Terraform-inspired declarative tool to sync overlapping instruction markdown files using an LLM engine**
+
+## 0) Summary
+
+`instrctl` manages “instruction documents” (e.g. `CLAUDE.md`, `agents.md`, `bugbot.md`, `skills.md`, Cursor rules files) across a git repo. It creates a single canonical representation of rules (“principles”), detects conflicts, and can apply consistent updates across all relevant docs via PR.
+
+It supports three core commands:
+
+* **init**: discover docs → extract principles → write `state.json` + `conflicts.json`/`conflicts.md`
+* **plan**: compare desired principles vs state → produce a validated patch plan (diffs)
+* **apply**: apply plan → commit branch → open PR → update state
+
+Key constraints:
+
+* LLM outputs must be **schema-constrained** and **patch-bounded** (no freeform rewriting).
+* Edits must be **deterministic** and validated by deterministic code.
+* Tool must be safe: only modifies allowlisted files/sections; never touches code unless explicitly configured.
+
+---
+
+## 1) Goals & Non-goals
+
+### Goals
+
+1. **Canonicalize** all guideline definitions into a single state representation (“Principles”).
+2. **Detect conflicts** across scopes and documents (duplication, contradiction, mismatch).
+3. Provide a Terraform-like workflow: init/plan/apply.
+4. **Apply synchronized updates** across docs and scopes through **pull requests**.
+5. Be robust to heterogeneous instruction formats and document styles.
+6. Minimize diffs; maintain human readability.
+
+### Non-goals (explicitly out of scope)
+
+* Enforcing or executing rules in runtime (that’s for linters/CI).
+* Refactoring codebase behavior to satisfy principles.
+* Perfect semantic understanding of rules (LLM-assisted, but validated).
+* Managing non-markdown binary artifacts.
+
+---
+
+## 2) Glossary & Semantics
+
+### 2.1 Principle
+
+The smallest independently-managed guideline.
+
+Required fields:
+
+* `id` (stable string; generated once on init; thereafter tracked)
+* `title`
+* `strength` (enum: `MUST`, `SHOULD`, `MAY`, `MUST_NOT`)
+* `statement` (canonical normative text)
+* `scope` (list of git path globs; e.g. ["repo/**"], ["frontend/**"])
+* `tags` (optional list)
+* `rationale` (optional)
+* `examples` (optional list)
+
+### 2.2 Document
+
+A markdown instruction file treated as a projection target.
+
+* `path`
+* `dialect` (enum: `generic`, `claude`, `cursor`, `agents`, `bugbot`, `skills`, `custom`)
+* `doc_scope` (path globs inferred from file location + optional frontmatter)
+* `sha256` (content hash)
+
+### 2.3 Occurrence
+
+A mapping from a principle to a concrete block in a document.
+
+* `principle_id`
+* `doc_path`
+* `span` (line range)
+* `raw_text_hash`
+* `anchor` (optional marker-based anchor if “managed blocks” exist)
+
+### 2.4 Scope
+
+A list of glob patterns (gitignore-like) that define applicability.
+
+#### Scope intersection rule
+
+A principle applies to a document if:
+
+* `doc_path` matches any pattern in `principle.scope` **AND**
+* document `doc_scope` intersects principle scope (unless doc_scope is unknown → assume `repo/**`)
+
+> Implementation MUST provide a deterministic “scope intersection” function that returns “unknown/possible” vs “disjoint” vs “intersects” for imperfect cases.
+
+---
+
+## 3) Repo Layout & Artifacts
+
+`instrctl` stores its artifacts in `.instrctl/`.
+
+```
+.instrctl/
+  instrctl.hcl           # desired declarative configuration (optional but recommended)
+  state.json             # generated source-of-truth mapping + extracted principles
+  conflicts.json         # generated conflict data
+  conflicts.md           # generated human report
+  plan.json              # generated plan output with patches
+  cache/                 # LLM cache (by prompt+model+input hash)
+```
+
+### Artifact rules
+
+* `state.json` is authoritative for **identity** (principle IDs).
+* `instrctl.hcl` is authoritative for **desired state** during plan/apply.
+* `conflicts.*` are derived.
+* `plan.json` is required input to `apply` unless `apply` performs an internal `plan` (optional feature).
+
+---
+
+## 4) CLI Specification
+
+### 4.1 Command overview
+
+```
+instrctl init [--config .instrctl/instrctl.hcl] [--write-config] [--include PATTERN...] [--exclude PATTERN...]
+instrctl plan [--config .instrctl/instrctl.hcl] [--out .instrctl/plan.json] [--patch-out plan.diff] [--fail-on-conflicts]
+instrctl apply [--plan .instrctl/plan.json] [--branch BRANCH] [--pr] [--remote origin] [--provider github|gitlab] [--dry-run]
+instrctl check [--config ...]   # CI mode: fails if drift/conflicts exist
+instrctl fmt [--config ...]     # formats HCL and/or managed blocks (optional)
+```
+
+### 4.2 Exit codes (strict)
+
+* `0`: success
+* `1`: generic failure
+* `2`: conflicts detected (when `--fail-on-conflicts` or `check`)
+* `3`: plan required/outdated (`apply` without valid plan)
+* `4`: patch validation failed (LLM patch unsafe / violates constraints)
+* `5`: git/PR operation failed
+
+### 4.3 Terraform-like UX requirements
+
+* `plan` prints a human-readable summary plus shows unified diffs.
+* `apply` prints branch name + PR URL (if created).
+* `check` prints any drift/conflict summary.
+
+---
+
+## 5) Instruction Document Discovery
+
+### 5.1 Default include patterns
+
+MUST scan repo (tracked files) for:
+
+* `**/agents.md`
+* `**/bugbot.md`
+* `**/skills.md`
+* `**/CLAUDE.md`, `**/claude.md`
+* `**/.cursor/rules*`
+* `**/cursor-rules*`
+* Optionally: `**/*instruction*.md` (behind a flag; default OFF to avoid noise)
+
+### 5.2 Excludes (defaults)
+
+* `.git/**`
+* `node_modules/**`, `vendor/**`, `dist/**`, `build/**`
+* binaries
+
+### 5.3 Dialect detection (deterministic)
+
+* If filename matches known: `CLAUDE.md` → `claude`, `agents.md` → `agents`, etc.
+* Cursor rules files → `cursor`
+* Else `generic`
+
+### 5.4 doc_scope inference
+
+doc_scope is used to understand “local overrides” by folder:
+
+* If file is at repo root → ["repo/**"]
+* If file is under `path/to/subdir/` → default doc_scope is ["path/to/subdir/**"]
+* If file includes frontmatter:
+
+  ```md
+  ---
+  instrctl:
+    scope: ["frontend/**"]
+  ---
+  ```
+
+  then that overrides inferred doc_scope.
+
+---
+
+## 6) Declarative Desired State (instrctl.hcl)
+
+### 6.1 Required blocks
+
+#### `principle` block
+
+```hcl
+principle "P-2F9C1A" {
+  title     = "Matplotlib only"
+  strength  = "MUST_NOT"
+  statement = "Do NOT use seaborn for charts; use matplotlib only."
+  scope     = ["repo/**"]
+  tags      = ["python", "visualization"]
+  rationale = "Consistency and fewer dependencies."
+  examples  = [
+    "Use matplotlib.pyplot for plots.",
+    "Do not import seaborn."
+  ]
+}
+```
+
+#### `override` block
+
+Overrides must be explicit to prevent “silent contradiction”:
+
+```hcl
+override "P-BASEID" "P-OVERRIDEID" {
+  scope     = ["frontend/**"]
+  statement = "Frontend copy-only changes MAY omit tests."
+  reason    = "No stable UI test suite yet."
+  expires_on = "2026-06-01"  # optional
+}
+```
+
+### 6.2 Config for discovery/rendering (optional)
+
+```hcl
+settings {
+  include = ["**/CLAUDE.md", "**/agents.md", "**/bugbot.md", "**/skills.md", "**/.cursor/rules*"]
+  exclude = ["vendor/**", "node_modules/**"]
+  managed_blocks = true
+}
+
+rendering {
+  dialect "claude" {
+    section_heading = "## Instructions"
+  }
+  dialect "agents" {
+    section_heading = "## Agent Rules"
+  }
+  default_section_heading = "## Managed Principles"
+}
+```
+
+---
+
+## 7) State, Plan, Conflicts: Schemas
+
+### 7.1 state.json (canonical state)
+
+#### Required fields
+
+* `version`
+* `repo.root`
+* `repo.head_commit`
+* `repo.tracked_patterns`
+* `documents[]`
+* `principles[]`
+* `occurrences[]`
+* `llm` metadata
+
+#### JSON Schema (implementation MUST validate)
+
+You can embed this in code as JSON Schema or equivalent type validation.
+
+**High-level structure (abbreviated but contract-grade):**
+
+```json
+{
+  "version": 1,
+  "repo": {"root": "...", "head_commit": "..."},
+  "documents": [
+    {
+      "path": "CLAUDE.md",
+      "dialect": "claude",
+      "doc_scope": ["repo/**"],
+      "sha256": "..."
+    }
+  ],
+  "principles": [
+    {
+      "id": "P-XXXXXX",
+      "title": "string",
+      "strength": "MUST|SHOULD|MAY|MUST_NOT",
+      "statement": "string",
+      "scope": ["glob", "..."],
+      "tags": ["..."],
+      "rationale": "string?",
+      "examples": ["..."],
+      "sources": [
+        {"doc": "path", "span": {"start_line": 1, "end_line": 10}, "raw_text_hash": "..."}
+      ],
+      "fingerprint": "sha256(normalized statement + strength + tags?)"
+    }
+  ],
+  "occurrences": [
+    {
+      "principle_id": "P-XXXXXX",
+      "doc": "path",
+      "span": {"start_line": 10, "end_line": 20},
+      "anchor": "instrctl:begin P-XXXXXX"
+    }
+  ],
+  "llm": {
+    "provider": "openai|anthropic|local",
+    "model": "string",
+    "prompt_versions": {"extract": "v1", "conflicts": "v1", "patch": "v1"}
+  }
+}
+```
+
+### 7.2 conflicts.json
+
+```json
+{
+  "version": 1,
+  "base_commit": "abc123",
+  "conflicts": [
+    {
+      "conflict_id": "C-0007",
+      "type": "DUPLICATE|CONTRADICTION|PARAMETER_MISMATCH|OVERRIDE_MISSING|AMBIGUOUS_SCOPE",
+      "severity": "LOW|MEDIUM|HIGH",
+      "topic": "string",
+      "principle_ids": ["P-1", "P-2"],
+      "overlapping_scope": ["glob", "..."],
+      "evidence": [{"doc": "path", "span": {"start_line": 1, "end_line": 3}}],
+      "explanation": "string",
+      "suggested_resolution": "string",
+      "blocking": true
+    }
+  ]
+}
+```
+
+### 7.3 plan.json
+
+```json
+{
+  "version": 1,
+  "base_commit": "abc123",
+  "principle_changes": [
+    {"action": "create|update|delete", "id": "P-...", "before_hash": "...?", "after_hash": "...?"}
+  ],
+  "file_patches": [
+    {"path": "CLAUDE.md", "patch_unified": "diff..."},
+    {"path": "agents.md", "patch_unified": "diff..."}
+  ],
+  "conflicts": [{"conflict_id": "C-0007", "blocking": true}],
+  "validation": {
+    "patch_constraints_ok": true,
+    "roundtrip_ok": true
+  }
+}
+```
+
+---
+
+## 8) init: Extraction & Conflict Detection
+
+### 8.1 init flow (step-by-step)
+
+1. Ensure repo root discovered (git).
+2. Enumerate candidate files using include/exclude rules.
+3. Read each document; compute sha256.
+4. Parse document into “sections” (headings) and raw text blocks.
+5. Extract principles using LLM (see §11 prompts).
+6. Assign principle IDs:
+
+   * If no previous state exists: generate new ID (`P-` + 6–8 chars) from cryptographic random.
+   * If previous state exists (future enhancement): attempt matching by fingerprint similarity to reuse IDs.
+7. Emit `state.json` with principles + occurrences.
+8. Run conflict detection (heuristics + LLM classification on candidates).
+9. Write `conflicts.json` and `conflicts.md`.
+
+### 8.2 Extraction rules
+
+* A principle must contain:
+
+  * a normative keyword (MUST/SHOULD/MAY/MUST NOT) OR equivalent modal language
+* Prefer splitting large lists into atomic principles.
+* Preserve source spans.
+
+**Normalization (for fingerprints)**
+
+* Lowercase statement
+* collapse whitespace
+* strip punctuation except negation markers
+* include `strength` in fingerprint
+
+### 8.3 Managed blocks adoption (init behavior)
+
+Default: init does **not** edit files.
+
+Optional feature `init --write-config`:
+
+* generates `.instrctl/instrctl.hcl` containing extracted principles
+* marks it as “generated; please edit”
+
+---
+
+## 9) Conflict Detection Rules
+
+### 9.1 Candidate generation (deterministic pre-filter)
+
+To avoid O(n²), generate candidate pairs by:
+
+* same tag overlap OR same dialect cluster OR cosine similarity of token TF-IDF (local)
+* plus scope intersection likely true
+
+### 9.2 Conflict classification
+
+For each candidate pair/cluster:
+
+* Determine scope overlap
+* Classify:
+
+  * DUPLICATE: same meaning, different wording
+  * CONTRADICTION: must vs must_not or mutually exclusive requirements
+  * PARAMETER_MISMATCH: same rule but different thresholds (e.g. “90% coverage” vs “80%”)
+  * OVERRIDE_MISSING: specific rule contradicts general but no override declared
+  * AMBIGUOUS_SCOPE: unclear applicability
+
+LLM is allowed to:
+
+* assign topic label
+* classify type
+* provide explanation and suggested resolution
+
+### 9.3 Blocking rules
+
+Default:
+
+* `CONTRADICTION/HIGH` blocks `apply` and fails `check`
+* `OVERRIDE_MISSING/HIGH` blocks (because it’s likely unintentional)
+* DUPLICATE doesn’t block but is reported
+
+Override mechanism:
+
+* A conflict can be “resolved” by explicit override blocks in config.
+
+---
+
+## 10) plan: Desired State → Patches
+
+### 10.1 Inputs
+
+* `.instrctl/state.json` (must exist)
+* `.instrctl/instrctl.hcl` (desired declarations)
+* current working tree (should be clean; if not, plan should warn and continue or fail based on flag)
+
+### 10.2 Plan computation
+
+1. Load state principles (current).
+2. Load config principles+overrides (desired).
+3. Compute change set:
+
+   * create: in config not in state
+   * update: same id, different canonical fields
+   * delete: present in state but removed from config (only if explicitly enabled; default: do not delete unmanaged principles unless flag `--allow-delete`)
+4. Determine impacted docs per principle change:
+
+   * docs whose `doc_scope` intersects principle scope
+   * dialect rules may exclude inclusion (configurable)
+5. For each impacted doc, determine edit operations:
+
+   * If occurrence exists: update that span (prefer managed blocks)
+   * Else: insert principle into dialect section (create section if missing)
+
+### 10.3 Where to insert (deterministic)
+
+For each doc:
+
+* If managed blocks are enabled and section exists: insert under that section.
+* Else look for heading candidates by dialect:
+
+  * `claude`: `## Instructions`, `## Guidelines`
+  * `agents`: `## Agent Rules`, `## Rules`
+  * `skills`: `## Standards`, `## Workflow`
+* If none found: append a new section:
+
+  * `## Managed Principles`
+  * include a short explanation comment line
+
+Insertion order:
+
+* sort by `strength` (MUST_NOT, MUST, SHOULD, MAY) then `title`
+
+### 10.4 Patch generation contract
+
+LLM may be used for:
+
+* rewriting a specific principle text into target dialect style (still same meaning)
+* generating minimal patch for bounded region
+
+But the tool MUST constrain:
+
+* allowed files
+* allowed spans
+* insertion points
+* output must be unified diff
+* patch must pass deterministic validation
+
+**Patch constraints**
+
+* Only files discovered in init (or explicitly allowed new docs) may be modified.
+* Only lines within:
+
+  * `<!-- instrctl:begin ... -->` / `<!-- instrctl:end ... -->` blocks
+  * OR the `## Managed Principles` section (tool-managed region)
+* No other lines may change.
+* Diff must apply cleanly on `plan.base_commit`.
+
+### 10.5 Round-trip validation (mandatory)
+
+After applying patch in-memory:
+
+* Re-run extraction on modified docs (fast-path parser).
+* Ensure the extracted principles for those blocks match desired state:
+
+  * `id` preserved
+  * `strength` preserved
+  * statement semantically equivalent (use fingerprint match or LLM equivalence check; prefer deterministic fingerprint if rendering preserves canonical statement)
+
+**Recommended approach**
+
+* Store canonical statement in managed block as a single line to preserve fingerprint determinism, and allow dialect formatting around it.
+
+---
+
+## 11) LLM Integration Spec (Engine Contract)
+
+### 11.1 Provider interface
+
+Implementation must define an interface:
+
+* `ExtractPrinciples(document_text, dialect, doc_path, doc_scope) -> ExtractResult`
+* `ClassifyConflicts(principles_cluster) -> ConflictResult`
+* `GeneratePatch(context, constraints, desired_snippet) -> UnifiedDiff`
+
+Providers:
+
+* `openai`
+* `anthropic`
+* `local` (optional)
+
+### 11.2 Strict schemas for responses
+
+Responses MUST be parsed with strict JSON schema validation.
+
+#### ExtractResult schema
+
+```json
+{
+  "principles": [
+    {
+      "title": "string",
+      "strength": "MUST|SHOULD|MAY|MUST_NOT",
+      "statement": "string",
+      "tags": ["string"],
+      "rationale": "string?",
+      "examples": ["string"],
+      "source_span": {"start_line": 1, "end_line": 5}
+    }
+  ]
+}
+```
+
+#### PatchResult schema
+
+Either:
+
+* `{ "patch_unified": "diff..." }`
+
+No other content allowed.
+
+### 11.3 Prompting constraints
+
+* Temperature low (0–0.3).
+* Must include file path, dialect, and explicit rules like:
+
+  * “Do not add new requirements”
+  * “Do not modify outside bounded lines”
+* Provide examples of acceptable output.
+
+### 11.4 Caching
+
+Cache key:
+
+* `(provider, model, prompt_version, input_sha256)`
+  Store:
+* raw response
+* parsed response
+* validation result
+
+---
+
+## 12) Managed Blocks (Strong Recommendation)
+
+### 12.1 Marker format
+
+Use HTML comments:
+
+```md
+<!-- instrctl:begin P-2F9C1A -->
+- **MUST NOT** use seaborn for charts; use matplotlib only.
+<!-- instrctl:end P-2F9C1A -->
+```
+
+### 12.2 Adoption policy
+
+* `init` does not modify docs
+* First `apply` may add managed blocks if `settings.managed_blocks=true`
+* If a doc already contains blocks, use them
+
+### 12.3 Human editing rules
+
+Humans can edit inside blocks; `instrctl` will overwrite to match desired state on apply.
+
+---
+
+## 13) apply: Git & Pull Request Workflow
+
+### 13.1 Preconditions
+
+* working tree clean OR `--allow-dirty` (default: fail if dirty)
+* HEAD commit equals `plan.base_commit` (default: fail; optional: allow rebase mode)
+
+### 13.2 Apply steps
+
+1. Read `plan.json`
+2. Validate plan still applies:
+
+   * base_commit matches HEAD
+   * patches apply cleanly in-memory
+3. Write updated files
+4. Run validation:
+
+   * patch constraints check
+   * round-trip principle match
+5. Create branch (default): `instrctl/apply-YYYYMMDD-HHMMSS`
+6. Commit with message:
+
+   * `instrctl: sync principles (N changes)`
+7. Push to remote
+8. Create PR (if `--pr`):
+
+   * Title: `Sync instruction principles`
+   * Body includes:
+
+     * summary of principle changes
+     * conflicts resolved / remaining
+     * “Managed by instrctl” note
+
+### 13.3 PR providers
+
+Minimum viable:
+
+* GitHub via `gh` CLI OR API token env var.
+* GitLab (optional second provider).
+
+Provider config:
+
+```hcl
+vcs {
+  provider = "github"
+  remote   = "origin"
+  repo     = "org/name"
+}
+```
+
+---
+
+## 14) Deterministic Safety Checks (MUST implement)
+
+These are non-negotiable to avoid LLM-induced repo damage.
+
+### 14.1 Allowed file set
+
+* Only files discovered in init may be modified, unless config explicitly allows creating a new instruction doc.
+
+### 14.2 Allowed region check
+
+For each patch:
+
+* Parse unified diff
+* For each hunk, verify:
+
+  * modified lines fall within a managed block OR managed section boundaries
+  * else fail with exit code `4`
+
+### 14.3 No code modification default
+
+Default policy:
+
+* do not modify files outside instruction doc patterns
+* config can opt-in additional files but must be explicit
+
+### 14.4 Plan/apply idempotency
+
+Two consecutive apply runs on same desired config should result in no changes (clean plan).
+
+---
+
+## 15) Rendering & Dialect Adapters
+
+### 15.1 Canonical vs rendered text
+
+Canonical statement must remain stable; rendered text may vary by dialect but must not change meaning.
+
+Recommended rendering template:
+
+* Bullet with strength emphasized:
+
+  * `- **MUST** …`
+  * `- **MUST NOT** …`
+
+Optional dialect expansions:
+
+* claude: add “When in doubt…” style clarifications (but only if derived from canonical rationale/examples)
+
+### 15.2 Adapter contract
+
+`render(principle, dialect) -> markdown_block`
+
+Rules:
+
+* Must include the `strength` keyword explicitly.
+* Must include the canonical `statement` verbatim OR embed it as a machine-readable string inside the managed block (preferred for round-trip).
+
+---
+
+## 16) Testing & CI Requirements
+
+### 16.1 Unit tests (required)
+
+* Glob scope intersection function
+* Document discovery include/exclude
+* Markdown heading/section detection
+* Managed block parsing and span location
+* Unified diff parsing + allowed-region validation
+* State/config diff computation (create/update/delete)
+
+### 16.2 Integration tests (required)
+
+Create a `testdata/` repo fixture with:
+
+* overlapping scopes
+* contradictions (pnpm vs yarn)
+* duplicates across docs
+* missing headings (forces fallback section insertion)
+
+Test flows:
+
+* `init` produces stable `state.json` and `conflicts.json`
+* `plan` produces expected patch
+* `apply` applies patch in a temp git repo without PR creation
+
+### 16.3 Golden file testing
+
+* Snapshot `conflicts.md` and `plan.diff` in fixtures.
+
+### 16.4 CI “check” mode
+
+`instrctl check` must:
+
+* fail if conflicts blocking
+* fail if docs drift from config (rendered blocks mismatch desired)
+* print actionable output
+
+---
+
+## 17) Performance Requirements
+
+* Repo scan should be incremental:
+
+  * skip unchanged docs via sha256 + cache
+* LLM calls:
+
+  * extraction calls only for changed docs
+  * conflict classification only on candidate clusters
+  * patch generation only for bounded regions
+
+---
+
+## 18) Milestones & Deliverables (Implementation Plan)
+
+### Milestone A — Core init
+
+Deliver:
+
+* CLI skeleton
+* discovery
+* extraction (LLM provider stub + schema validation)
+* state.json writing
+* basic conflict detection (heuristics only) + conflicts.md
+
+### Milestone B — plan with deterministic patch constraints
+
+Deliver:
+
+* config parser for HCL
+* diff of desired vs state
+* render adapters (basic)
+* bounded patch generation
+* patch validation (allowed regions, apply cleanly)
+* plan.json output + printed diff
+
+### Milestone C — apply via PR
+
+Deliver:
+
+* apply plan patches
+* git branch/commit/push
+* GitHub PR creation (at least via `gh`)
+
+### Milestone D — Robustness & adoption
+
+Deliver:
+
+* managed blocks adoption on apply
+* override semantics + conflict resolution rules
+* check command for CI
+* caching
+
+---
+
+## 19) Open Decisions (Make defaults, don’t block implementation)
+
+To avoid stalling, implement with defaults:
+
+1. **ID generation**: random stable IDs at init; stored in state.
+2. **Canonical statement**: stored verbatim in managed block for deterministic matching.
+3. **Overrides**: required to legalize contradictions in narrower scopes.
+4. **Where to write config**: optional `init --write-config` to bootstrap.
+
+---
+
+## 20) Concrete Acceptance Criteria (Definition of Done)
+
+A repo containing:
+
+* `CLAUDE.md` at root
+* `frontend/agents.md`
+* `skills.md`
+  with overlapping, contradictory rules…
+
+Must support:
+
+1. `instrctl init` generates state + conflicts with correct spans and at least one contradiction detected.
+2. Editing `.instrctl/instrctl.hcl` to resolve contradiction causes:
+
+   * `instrctl plan` to output a patch affecting all relevant docs
+3. `instrctl apply --pr`:
+
+   * creates a branch
+   * commits changes
+   * opens a PR
+4. Running `instrctl plan` again yields **no diff**.
+
+---
+
+## Appendix A: conflicts.md format (human report)
+
+Must include:
+
+* Summary counts by severity/type
+* Each conflict with:
+
+  * involved principle IDs
+  * doc paths and line ranges
+  * explanation and suggested resolution
+  * whether blocking
+
+---
+
+## Appendix B: Security / Privacy
+
+* Never send non-instruction files to LLM by default.
+* Provide config option `settings.llm_redaction=true` to redact emails/secrets patterns.
+* Store LLM cache locally; do not commit `.instrctl/cache/`.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "watch": "tsc --watch",
+    "test": "node --test --import tsx --test-reporter spec test/**/*.test.ts",
     "lint": "eslint src --cache",
     "lint:fix": "eslint src --fix",
     "format:fix": "prettier --write \"**/*.{ts,tsx}\"",

--- a/src/commands/instrctl.ts
+++ b/src/commands/instrctl.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { applyPlan } from "../instrctl/apply.js";
 import { buildPlan } from "../instrctl/plan.js";
 import { writeStateFiles } from "../instrctl/state.js";
+import { readConflicts } from "../instrctl/utils.js";
 
 export function createInstrctlCommand(): Command {
   const cmd = new Command("instrctl");
@@ -11,25 +12,59 @@ export function createInstrctlCommand(): Command {
     .command("init")
     .description("Discover instruction documents and generate state")
     .action(async () => {
-      const { state, conflicts } = await writeStateFiles();
-      console.log(`Found ${state.documents.length} documents and ${state.principles.length} principles.`);
-      console.log(`Conflicts written to .instrctl/conflicts.json (${conflicts.conflicts.length} entries).`);
+      try {
+        const { state, conflicts } = await writeStateFiles();
+        console.log(`Found ${state.documents.length} documents and ${state.principles.length} principles.`);
+        console.log(`Conflicts written to .instrctl/conflicts.json (${conflicts.conflicts.length} entries).`);
+        if (conflicts.conflicts.some((c) => c.blocking)) {
+          process.exit(2);
+        }
+      } catch (error) {
+        console.error(String(error));
+        process.exit(1);
+      }
     });
 
   cmd
     .command("plan")
     .description("Compute a plan to align documents with desired principles")
     .action(() => {
-      const plan = buildPlan();
-      console.log(`Generated plan with ${plan.file_patches.length} file patches.`);
+      try {
+        const conflicts = readConflicts();
+        if (conflicts?.conflicts.some((c) => c.blocking)) {
+          console.error("Blocking conflicts detected; resolve before planning.");
+          process.exit(2);
+          return;
+        }
+        const plan = buildPlan();
+        if (plan.conflicts.some((c) => c.blocking)) {
+          console.error("Blocking conflicts detected in plan output.");
+          process.exit(2);
+          return;
+        }
+        if (!plan.validation.patch_constraints_ok) {
+          console.error("Patch validation failed while building plan.");
+          process.exit(4);
+          return;
+        }
+        console.log(`Generated plan with ${plan.file_patches.length} file patches.`);
+      } catch (error: any) {
+        console.error(String(error));
+        process.exit(error?.exitCode ?? 1);
+      }
     });
 
   cmd
     .command("apply")
     .description("Apply the previously generated plan")
     .action(async () => {
-      const plan = await applyPlan();
-      console.log(`Applied ${plan.file_patches.length} patches.`);
+      try {
+        const plan = await applyPlan();
+        console.log(`Applied ${plan.file_patches.length} patches.`);
+      } catch (error: any) {
+        console.error(String(error));
+        process.exit(error?.exitCode ?? 1);
+      }
     });
 
   return cmd;

--- a/src/commands/instrctl.ts
+++ b/src/commands/instrctl.ts
@@ -1,0 +1,36 @@
+import { Command } from "commander";
+import { applyPlan } from "../instrctl/apply.js";
+import { buildPlan } from "../instrctl/plan.js";
+import { writeStateFiles } from "../instrctl/state.js";
+
+export function createInstrctlCommand(): Command {
+  const cmd = new Command("instrctl");
+  cmd.description("Manage instruction documents and keep them in sync");
+
+  cmd
+    .command("init")
+    .description("Discover instruction documents and generate state")
+    .action(async () => {
+      const { state, conflicts } = await writeStateFiles();
+      console.log(`Found ${state.documents.length} documents and ${state.principles.length} principles.`);
+      console.log(`Conflicts written to .instrctl/conflicts.json (${conflicts.conflicts.length} entries).`);
+    });
+
+  cmd
+    .command("plan")
+    .description("Compute a plan to align documents with desired principles")
+    .action(() => {
+      const plan = buildPlan();
+      console.log(`Generated plan with ${plan.file_patches.length} file patches.`);
+    });
+
+  cmd
+    .command("apply")
+    .description("Apply the previously generated plan")
+    .action(async () => {
+      const plan = await applyPlan();
+      console.log(`Applied ${plan.file_patches.length} patches.`);
+    });
+
+  return cmd;
+}

--- a/src/commands/instrctl.ts
+++ b/src/commands/instrctl.ts
@@ -28,17 +28,12 @@ export function createInstrctlCommand(): Command {
   cmd
     .command("plan")
     .description("Compute a plan to align documents with desired principles")
-    .action(() => {
       try {
-        const conflicts = readConflicts();
-        if (conflicts?.conflicts.some((c) => c.blocking)) {
+        const repoRoot = getRepoRoot();
+        const state = readState(repoRoot);
+        const conflicts = buildConflicts(state.repo.head_commit, state.principles);
+        if (conflicts.conflicts.some((c) => c.blocking)) {
           console.error("Blocking conflicts detected; resolve before planning.");
-          process.exit(2);
-          return;
-        }
-        const plan = buildPlan();
-        if (plan.conflicts.some((c) => c.blocking)) {
-          console.error("Blocking conflicts detected in plan output.");
           process.exit(2);
           return;
         }

--- a/src/commands/instrctl.ts
+++ b/src/commands/instrctl.ts
@@ -48,9 +48,10 @@ export function createInstrctlCommand(): Command {
           return;
         }
         console.log(`Generated plan with ${plan.file_patches.length} file patches.`);
-      } catch (error: any) {
+      } catch (error: unknown) {
+        const err = error as { exitCode?: number };
         console.error(String(error));
-        process.exit(error?.exitCode ?? 1);
+        process.exit(err?.exitCode ?? 1);
       }
     });
 
@@ -61,9 +62,10 @@ export function createInstrctlCommand(): Command {
       try {
         const plan = await applyPlan();
         console.log(`Applied ${plan.file_patches.length} patches.`);
-      } catch (error: any) {
+      } catch (error: unknown) {
+        const err = error as { exitCode?: number };
         console.error(String(error));
-        process.exit(error?.exitCode ?? 1);
+        process.exit(err?.exitCode ?? 1);
       }
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { render } from "ink";
 import React from "react";
 import ReviewFlow from "./flows/Review/Review.js";
 import { createAuthCommand } from "./commands/auth.js";
+import { createInstrctlCommand } from "./commands/instrctl.js";
 import {
   AppModeProvider,
   getAppConfig,
@@ -50,5 +51,6 @@ program
   });
 
 program.addCommand(createAuthCommand());
+program.addCommand(createInstrctlCommand());
 
 program.parseAsync();

--- a/src/instrctl/apply.ts
+++ b/src/instrctl/apply.ts
@@ -1,0 +1,33 @@
+import fs from "fs";
+import path from "path";
+import { execSync } from "child_process";
+import { readState, writeStateFiles } from "./state.js";
+import { getRepoRoot } from "./utils.js";
+import type { PlanFile } from "./types.js";
+
+export function readPlan(repoRoot: string): PlanFile {
+  const planPath = path.join(repoRoot, ".instrctl", "plan.json");
+  if (!fs.existsSync(planPath)) {
+    throw new Error(".instrctl/plan.json missing; run instrctl plan first.");
+  }
+  const content = fs.readFileSync(planPath, "utf8");
+  return JSON.parse(content) as PlanFile;
+}
+
+function applyPatch(patch: string) {
+  execSync("git apply --whitespace=nowarn", { input: patch, stdio: "pipe" });
+}
+
+export async function applyPlan(): Promise<PlanFile> {
+  const repoRoot = getRepoRoot();
+  const state = readState(repoRoot);
+  const plan = readPlan(repoRoot);
+  if (state.repo.head_commit !== plan.base_commit) {
+    throw new Error("Plan base commit does not match HEAD; re-run plan.");
+  }
+  for (const patch of plan.file_patches) {
+    applyPatch(patch.patch_unified);
+  }
+  await writeStateFiles();
+  return plan;
+}

--- a/src/instrctl/apply.ts
+++ b/src/instrctl/apply.ts
@@ -1,9 +1,19 @@
 import fs from "fs";
 import path from "path";
 import { execSync } from "child_process";
+import { MANAGED_BEGIN, MANAGED_END, MANAGED_SECTION_HEADING } from "./constants.js";
 import { readState, writeStateFiles } from "./state.js";
 import { getRepoRoot } from "./utils.js";
-import type { PlanFile } from "./types.js";
+import type { FilePatch, PlanFile, StateFile } from "./types.js";
+
+class PlanValidationError extends Error {
+  exitCode: number;
+
+  constructor(message: string, exitCode: number) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
 
 export function readPlan(repoRoot: string): PlanFile {
   const planPath = path.join(repoRoot, ".instrctl", "plan.json");
@@ -18,16 +28,98 @@ function applyPatch(patch: string) {
   execSync("git apply --whitespace=nowarn", { input: patch, stdio: "pipe" });
 }
 
+function allowedRange(lines: string[]): { start: number; end: number } {
+  const begin = lines.findIndex((line) => line.includes(MANAGED_BEGIN));
+  if (begin >= 0) {
+    let heading = -1;
+    for (let i = begin; i >= 0; i -= 1) {
+      if (lines[i].includes(MANAGED_SECTION_HEADING)) {
+        heading = i;
+        break;
+      }
+    }
+    const endIndex = lines.slice(begin + 1).findIndex((line) => line.includes(MANAGED_END));
+    const absoluteEnd = endIndex >= 0 ? begin + 1 + endIndex : lines.length - 1;
+    return {
+      start: (heading >= 0 ? heading : begin) + 1,
+      end: absoluteEnd + 1,
+    };
+  }
+  return { start: lines.length + 1, end: Number.MAX_SAFE_INTEGER };
+}
+
+function validatePatchAgainstState(patch: FilePatch, state: StateFile, repoRoot: string) {
+  const allowedPaths = new Set(state.documents.map((doc) => doc.path));
+  if (!allowedPaths.has(patch.path)) {
+    throw new PlanValidationError(`Patch targets disallowed file: ${patch.path}`, 4);
+  }
+
+  const filePath = path.join(repoRoot, patch.path);
+  const before = fs.readFileSync(filePath, "utf8");
+  const lines = before.split(/\r?\n/);
+  const bounds = allowedRange(lines);
+
+  const diffLines = patch.patch_unified.split(/\r?\n/);
+  const originalLength = lines.length;
+  for (let i = 0; i < diffLines.length; i += 1) {
+    const line = diffLines[i];
+    if (!line.startsWith("@@")) continue;
+    const match = line.match(/@@ -([0-9]+)(?:,[0-9]+)? \+([0-9]+)/);
+    if (!match) continue;
+    let originalLine = Number(match[1]);
+
+    for (let j = i + 1; j < diffLines.length; j += 1) {
+      const hunkLine = diffLines[j];
+      if (hunkLine.startsWith("@@")) {
+        i = j - 1;
+        break;
+      }
+      if (hunkLine.startsWith(" ")) {
+        originalLine += 1;
+        continue;
+      }
+      if (hunkLine.startsWith("-")) {
+        if (originalLine < bounds.start || originalLine > bounds.end) {
+          throw new PlanValidationError(`Patch removes lines outside managed region in ${patch.path}`, 4);
+        }
+        originalLine += 1;
+        continue;
+      }
+      if (hunkLine.startsWith("+")) {
+        const targetLine = originalLine;
+        const withinFile = targetLine <= originalLength;
+        if (withinFile && (targetLine < bounds.start || targetLine > bounds.end)) {
+          throw new PlanValidationError(`Patch adds lines outside managed region in ${patch.path}`, 4);
+        }
+        if (!withinFile && bounds.start !== originalLength + 1) {
+          throw new PlanValidationError(`Patch appends outside managed region in ${patch.path}`, 4);
+        }
+        continue;
+      }
+      if (j === diffLines.length - 1) {
+        i = j;
+      }
+    }
+  }
+}
+
 export async function applyPlan(): Promise<PlanFile> {
   const repoRoot = getRepoRoot();
   const state = readState(repoRoot);
   const plan = readPlan(repoRoot);
   if (state.repo.head_commit !== plan.base_commit) {
-    throw new Error("Plan base commit does not match HEAD; re-run plan.");
+    throw new PlanValidationError("Plan base commit does not match HEAD; re-run plan.", 3);
   }
+
+  if (plan.conflicts.some((c) => c.blocking)) {
+    throw new PlanValidationError("Blocking conflicts detected in plan; resolve before applying.", 2);
+  }
+
   for (const patch of plan.file_patches) {
+    validatePatchAgainstState(patch, state, repoRoot);
     applyPatch(patch.patch_unified);
   }
+
   await writeStateFiles();
   return plan;
 }

--- a/src/instrctl/config.ts
+++ b/src/instrctl/config.ts
@@ -1,0 +1,55 @@
+import fs from "fs";
+import path from "path";
+import { getRepoRoot } from "./utils.js";
+import type { Principle } from "./types.js";
+
+export interface InstrctlConfig {
+  principles: Principle[];
+}
+
+function parseArray(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value.replace(/'/g, '"'));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseBlock(content: string): Record<string, string | string[]> {
+  const lines = content.split(/\r?\n/);
+  const result: Record<string, string | string[]> = {};
+  for (const line of lines) {
+    const match = line.trim().match(/^(\w+)\s*=\s*(.+)$/);
+    if (!match) continue;
+    const [, key, raw] = match;
+    if (raw.trim().startsWith("[")) {
+      result[key] = parseArray(raw.trim());
+    } else {
+      result[key] = raw.trim().replace(/^"|"$/g, "");
+    }
+  }
+  return result;
+}
+
+export function readConfig(repoRoot = getRepoRoot()): InstrctlConfig | null {
+  const configPath = path.join(repoRoot, ".instrctl", "instrctl.hcl");
+  if (!fs.existsSync(configPath)) return null;
+  const text = fs.readFileSync(configPath, "utf8");
+  const principleBlocks = [...text.matchAll(/principle\s+"([^"]+)"\s*\{([\s\S]*?)\}/g)];
+  const principles: Principle[] = principleBlocks.map((match) => {
+    const [, id, body] = match;
+    const values = parseBlock(body);
+    return {
+      id,
+      title: String(values.title ?? id),
+      strength: (values.strength as Principle["strength"]) ?? "MUST",
+      statement: String(values.statement ?? ""),
+      scope: (values.scope as string[]) ?? ["repo/**"],
+      tags: (values.tags as string[]) ?? [],
+      rationale: typeof values.rationale === "string" ? values.rationale : undefined,
+      examples: (values.examples as string[]) ?? [],
+    };
+  });
+  return { principles };
+}

--- a/src/instrctl/conflicts.ts
+++ b/src/instrctl/conflicts.ts
@@ -1,0 +1,65 @@
+import { normalizeStatement } from "./utils.js";
+import type { Conflict, ConflictsFile, Principle } from "./types.js";
+
+function detectDuplicates(principles: Principle[]): Conflict[] {
+  const seen = new Map<string, Principle>();
+  const conflicts: Conflict[] = [];
+  for (const principle of principles) {
+    const key = `${principle.strength}-${normalizeStatement(principle.statement)}`;
+    const existing = seen.get(key);
+    if (existing) {
+      conflicts.push({
+        conflictId: `C-${conflicts.length + 1}`,
+        type: "DUPLICATE",
+        severity: "LOW",
+        topic: principle.title,
+        principleIds: [existing.id, principle.id],
+        overlappingScope: existing.scope,
+        evidence: [],
+        explanation: "Principles share identical normalized text and strength.",
+        suggestedResolution: "Merge or deduplicate the overlapping principles.",
+        blocking: false,
+      });
+    } else {
+      seen.set(key, principle);
+    }
+  }
+  return conflicts;
+}
+
+function detectContradictions(principles: Principle[]): Conflict[] {
+  const conflicts: Conflict[] = [];
+  const map = new Map<string, Principle>();
+  for (const principle of principles) {
+    const normalized = normalizeStatement(principle.statement);
+    const inverseStrength = principle.strength === "MUST" ? "MUST_NOT" : "MUST";
+    const key = `${inverseStrength}-${normalized}`;
+    const candidate = map.get(key);
+    if (candidate) {
+      conflicts.push({
+        conflictId: `C-${conflicts.length + 1 + map.size}`,
+        type: "CONTRADICTION",
+        severity: "HIGH",
+        topic: principle.title,
+        principleIds: [candidate.id, principle.id],
+        overlappingScope: principle.scope,
+        evidence: [],
+        explanation: "Opposing strengths detected for the same normalized statement.",
+        suggestedResolution: "Add an override block or consolidate the rules.",
+        blocking: true,
+      });
+    }
+    map.set(`${principle.strength}-${normalized}`, principle);
+  }
+  return conflicts;
+}
+
+export function buildConflicts(baseCommit: string, principles: Principle[]): ConflictsFile {
+  const duplicates = detectDuplicates(principles);
+  const contradictions = detectContradictions(principles);
+  return {
+    version: 1,
+    base_commit: baseCommit,
+    conflicts: [...duplicates, ...contradictions],
+  };
+}

--- a/src/instrctl/constants.ts
+++ b/src/instrctl/constants.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_INCLUDE = [
+  "**/agents.md",
+  "**/bugbot.md",
+  "**/skills.md",
+  "**/CLAUDE.md",
+  "**/claude.md",
+  "**/.cursor/rules*",
+  "**/cursor-rules*",
+];
+
+export const DEFAULT_EXCLUDE = [
+  ".git/**",
+  "node_modules/**",
+  "vendor/**",
+  "dist/**",
+  "build/**",
+];
+
+export const MANAGED_SECTION_HEADING = "## Managed Principles";
+export const MANAGED_BEGIN = "<!-- instrctl:begin managed -->";
+export const MANAGED_END = "<!-- instrctl:end managed -->";

--- a/src/instrctl/discovery.ts
+++ b/src/instrctl/discovery.ts
@@ -1,0 +1,35 @@
+import fs from "fs";
+import path from "path";
+import { DEFAULT_EXCLUDE, DEFAULT_INCLUDE } from "./constants.js";
+import { docDialect, pathMatches } from "./matcher.js";
+import { repoEntries, relativePath, sha256 } from "./utils.js";
+import { inferDocScope } from "./scope.js";
+import type { DocumentDescriptor } from "./types.js";
+
+export interface DiscoveryOptions {
+  include?: string[];
+  exclude?: string[];
+}
+
+export function discoverDocuments(repoRoot: string, opts: DiscoveryOptions = {}): DocumentDescriptor[] {
+  const include = opts.include ?? DEFAULT_INCLUDE;
+  const exclude = opts.exclude ?? DEFAULT_EXCLUDE;
+  const files = repoEntries(repoRoot, exclude);
+  const docs: DocumentDescriptor[] = [];
+
+  for (const file of files) {
+    const rel = relativePath(repoRoot, file);
+    if (!pathMatches(rel, include, exclude)) continue;
+    const stat = fs.statSync(file);
+    if (!stat.isFile()) continue;
+    const content = fs.readFileSync(file, "utf8");
+    const docScope = inferDocScope(repoRoot, file, content);
+    docs.push({
+      path: rel,
+      dialect: docDialect(file),
+      docScope,
+      sha256: sha256(content),
+    });
+  }
+  return docs;
+}

--- a/src/instrctl/discovery.ts
+++ b/src/instrctl/discovery.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import path from "path";
 import { DEFAULT_EXCLUDE, DEFAULT_INCLUDE } from "./constants.js";
 import { docDialect, pathMatches } from "./matcher.js";
 import { repoEntries, relativePath, sha256 } from "./utils.js";

--- a/src/instrctl/extract.ts
+++ b/src/instrctl/extract.ts
@@ -1,0 +1,180 @@
+import axios from "axios";
+import { env } from "../lib/env-schema.js";
+import { normalizeStatement, sha256, inferenceTitle, idFromRandom } from "./utils.js";
+import type { Occurrence, Principle } from "./types.js";
+
+const MODAL_REGEX = /(MUST NOT|MUST|SHOULD|MAY)/i;
+
+export interface ExtractResult {
+  principles: Principle[];
+  occurrences: Occurrence[];
+}
+
+interface LlmPrinciplePayload {
+  title?: string;
+  strength: "MUST" | "MUST_NOT" | "SHOULD" | "MAY";
+  statement: string;
+  tags?: string[];
+  rationale?: string;
+  examples?: string[];
+  start_line?: number;
+  end_line?: number;
+}
+
+const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_MODEL = "claude-3-5-sonnet-latest";
+
+async function extractPrinciplesWithLlm(
+  docPath: string,
+  content: string,
+  defaultScope: string[],
+): Promise<ExtractResult | null> {
+  const apiKey = env.ANTHROPIC_TOKEN || env.BAZ_LLM_TOKEN || env.BAZ_TOKEN;
+  if (!apiKey) return null;
+
+  const prompt = [
+    "You are assisting instrctl, a tool that manages instruction documents in repositories.",
+    "Extract individual normative principles from the provided markdown file and respond with strict JSON only.",
+    "Each principle must include: strength (MUST, MUST_NOT, SHOULD, MAY), statement (concise requirement text),",
+    "optional title, tags, rationale, examples, and source line numbers start_line/end_line.",
+    "Do not invent requirements; only split atomic rules present in the text. Keep statements succinct and literal.",
+    "Return the JSON payload in the form { \"principles\": [ ... ] } with no trailing commentary.",
+    `Document path: ${docPath}`,
+  ].join("\n");
+
+  const body = {
+    model: ANTHROPIC_MODEL,
+    max_tokens: 1024,
+    system: prompt,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: content.slice(0, 16000),
+          },
+        ],
+      },
+    ],
+  };
+
+  try {
+    const response = await axios.post(ANTHROPIC_URL, body, {
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+    });
+
+    const messageContent = response.data?.content?.[0]?.text;
+    if (typeof messageContent !== "string") {
+      return null;
+    }
+    const parsed = JSON.parse(messageContent.trim()) as { principles?: LlmPrinciplePayload[] };
+    if (!parsed.principles?.length) return null;
+
+    const lines = content.split(/\r?\n/);
+    const principles: Principle[] = [];
+    const occurrences: Occurrence[] = [];
+
+    for (const principle of parsed.principles) {
+      const strength = principle.strength === "MUST NOT" ? "MUST_NOT" : principle.strength;
+      const statement = principle.statement.trim();
+      const normalized = normalizeStatement(statement);
+      if (!normalized) continue;
+      const id = idFromRandom();
+      const firstMatch = lines.findIndex((line) => line.includes(statement));
+      const inferredStart = firstMatch >= 0 ? firstMatch + 1 : 1;
+      const startLine = principle.start_line ?? inferredStart;
+      const endLine = principle.end_line ?? startLine;
+      principles.push({
+        id,
+        title: principle.title || inferenceTitle(statement),
+        strength,
+        statement,
+        scope: defaultScope,
+        tags: principle.tags,
+        rationale: principle.rationale,
+        examples: principle.examples,
+        sources: [
+          {
+            doc: docPath,
+            span: { startLine, endLine },
+            rawTextHash: sha256(lines[startLine - 1] || statement),
+          },
+        ],
+        fingerprint: sha256(`${strength}-${normalized}`),
+      });
+      occurrences.push({
+        principleId: id,
+        doc: docPath,
+        span: { startLine, endLine },
+      });
+    }
+
+    return { principles, occurrences };
+  } catch (error) {
+    console.warn("LLM extraction failed; falling back to heuristic parser", error);
+    return null;
+  }
+}
+
+function extractPrinciplesHeuristic(
+  docPath: string,
+  content: string,
+  defaultScope: string[],
+): ExtractResult {
+  const principles: Principle[] = [];
+  const occurrences: Occurrence[] = [];
+  const lines = content.split(/\r?\n/);
+
+  lines.forEach((line, idx) => {
+    const match = line.match(MODAL_REGEX);
+    if (!match) return;
+    const strengthRaw = match[1].toUpperCase();
+    const strength = strengthRaw === "MUST NOT" ? "MUST_NOT" : (strengthRaw as Principle["strength"]);
+    const cleaned = line
+      .replace(/^[-*]\s*/, "")
+      .replace(/`/g, "")
+      .replace(/\*\*/g, "")
+      .trim();
+    const statement = cleaned.replace(MODAL_REGEX, "").trim();
+    const normalized = normalizeStatement(statement);
+    if (!normalized) return;
+    const id = idFromRandom();
+    principles.push({
+      id,
+      title: inferenceTitle(statement),
+      strength,
+      statement,
+      scope: defaultScope,
+      sources: [
+        {
+          doc: docPath,
+          span: { startLine: idx + 1, endLine: idx + 1 },
+          rawTextHash: sha256(line),
+        },
+      ],
+      fingerprint: sha256(`${strength}-${normalized}`),
+    });
+    occurrences.push({
+      principleId: id,
+      doc: docPath,
+      span: { startLine: idx + 1, endLine: idx + 1 },
+    });
+  });
+
+  return { principles, occurrences };
+}
+
+export async function extractPrinciples(
+  docPath: string,
+  content: string,
+  defaultScope: string[],
+): Promise<ExtractResult> {
+  const llmResult = await extractPrinciplesWithLlm(docPath, content, defaultScope);
+  if (llmResult) return llmResult;
+  return extractPrinciplesHeuristic(docPath, content, defaultScope);
+}

--- a/src/instrctl/extract.ts
+++ b/src/instrctl/extract.ts
@@ -12,7 +12,7 @@ export interface ExtractResult {
 
 interface LlmPrinciplePayload {
   title?: string;
-  strength: "MUST" | "MUST_NOT" | "SHOULD" | "MAY";
+  strength: "MUST" | "MUST_NOT" | "MUST NOT" | "SHOULD" | "MAY";
   statement: string;
   tags?: string[];
   rationale?: string;
@@ -80,7 +80,7 @@ async function extractPrinciplesWithLlm(
     const occurrences: Occurrence[] = [];
 
     for (const principle of parsed.principles) {
-      const strength = principle.strength === "MUST NOT" ? "MUST_NOT" : principle.strength;
+      const strength = principle.strength.replace(/\s+/g, "_").toUpperCase() as Principle["strength"];
       const statement = principle.statement.trim();
       const normalized = normalizeStatement(statement);
       if (!normalized) continue;

--- a/src/instrctl/extract.ts
+++ b/src/instrctl/extract.ts
@@ -116,7 +116,7 @@ async function extractPrinciplesWithLlm(
 
     return { principles, occurrences };
   } catch (error) {
-    console.warn("LLM extraction failed; falling back to heuristic parser", error);
+    console.warn("LLM extraction failed; falling back to heuristic parser");
     return null;
   }
 }

--- a/src/instrctl/extract.ts
+++ b/src/instrctl/extract.ts
@@ -115,7 +115,7 @@ async function extractPrinciplesWithLlm(
     }
 
     return { principles, occurrences };
-  } catch (error) {
+  } catch {
     console.warn("LLM extraction failed; falling back to heuristic parser");
     return null;
   }

--- a/src/instrctl/matcher.ts
+++ b/src/instrctl/matcher.ts
@@ -1,0 +1,57 @@
+import path from "path";
+
+export function globToRegex(pattern: string): RegExp {
+  const normalized = pattern.replace(/\\/g, "/");
+  const specials = new Set([".", "+", "^", "$", "{", "}", "(", ")", "|", "[", "]", "\\"]);
+  let body = "";
+  let i = 0;
+  let prefix = "";
+  if (normalized.startsWith("**/")) {
+    prefix = "(?:.*/)?";
+    i = 3;
+  }
+  for (; i < normalized.length; i += 1) {
+    const ch = normalized[i];
+    if (ch === "*") {
+      const isDouble = normalized[i + 1] === "*";
+      body += isDouble ? ".*" : "[^/]*";
+      if (isDouble) i += 1;
+      continue;
+    }
+    if (ch === "?") {
+      body += ".";
+      continue;
+    }
+    body += specials.has(ch) ? `\\${ch}` : ch;
+  }
+  return new RegExp(`^${prefix}${body}$`);
+}
+
+export function matchAny(file: string, patterns: string[]): boolean {
+  const normalized = file.replace(/\\/g, "/");
+  return patterns.some((p) => globToRegex(p).test(normalized));
+}
+
+export function pathMatches(file: string, include: string[], exclude: string[]): boolean {
+  const relative = file.replace(/\\/g, "/");
+  if (exclude.length && matchAny(relative, exclude)) return false;
+  if (!include.length) return true;
+  return matchAny(relative, include);
+}
+
+export function docDialect(file: string):
+  | "claude"
+  | "agents"
+  | "cursor"
+  | "bugbot"
+  | "skills"
+  | "generic" {
+  const normalized = file.replace(/\\/g, "/").toLowerCase();
+  const lower = path.basename(normalized);
+  if (lower === "claude.md") return "claude";
+  if (lower === "agents.md") return "agents";
+  if (lower === "bugbot.md") return "bugbot";
+  if (lower === "skills.md") return "skills";
+  if (lower.startsWith("cursor-rules") || normalized.includes("/.cursor/") || normalized.startsWith(".cursor/")) return "cursor";
+  return "generic";
+}

--- a/src/instrctl/matcher.ts
+++ b/src/instrctl/matcher.ts
@@ -5,9 +5,8 @@ export function globToRegex(pattern: string): RegExp {
   const specials = new Set([".", "+", "^", "$", "{", "}", "(", ")", "|", "[", "]", "\\"]);
   let body = "";
   let i = 0;
-  let prefix = "";
+  let prefix = "^(?:.*/)?";
   if (normalized.startsWith("**/")) {
-    prefix = "(?:.*/)?";
     i = 3;
   }
   for (; i < normalized.length; i += 1) {
@@ -24,7 +23,7 @@ export function globToRegex(pattern: string): RegExp {
     }
     body += specials.has(ch) ? `\\${ch}` : ch;
   }
-  return new RegExp(`^${prefix}${body}$`);
+  return new RegExp(`${prefix}${body}$`);
 }
 
 export function matchAny(file: string, patterns: string[]): boolean {

--- a/src/instrctl/matcher.ts
+++ b/src/instrctl/matcher.ts
@@ -5,7 +5,7 @@ export function globToRegex(pattern: string): RegExp {
   const specials = new Set([".", "+", "^", "$", "{", "}", "(", ")", "|", "[", "]", "\\"]);
   let body = "";
   let i = 0;
-  let prefix = "^(?:.*/)?";
+  const prefix = "^(?:.*/)?";
   if (normalized.startsWith("**/")) {
     i = 3;
   }

--- a/src/instrctl/plan.ts
+++ b/src/instrctl/plan.ts
@@ -88,7 +88,10 @@ export function buildPlan(): PlanFile {
   }
 
   const conflicts: PlanFile["conflicts"] = (conflictsFile?.conflicts ?? []).map((conflict) => ({
-    conflict_id: conflict.conflict_id,
+  const conflicts: PlanFile["conflicts"] = (conflictsFile?.conflicts ?? []).map((conflict) => ({
+    conflict_id: conflict.conflictId,
+    blocking: Boolean(conflict.blocking),
+  }));
     blocking: Boolean(conflict.blocking),
   }));
   const plan: PlanFile = {

--- a/src/instrctl/plan.ts
+++ b/src/instrctl/plan.ts
@@ -6,7 +6,7 @@ import { MANAGED_BEGIN, MANAGED_END, MANAGED_SECTION_HEADING } from "./constants
 import { readConfig } from "./config.js";
 import { scopeIntersects } from "./scope.js";
 import { readState } from "./state.js";
-import { ensureDir, getRepoRoot, writeFileSafe } from "./utils.js";
+import { ensureDir, getRepoRoot, readConflicts, writeFileSafe } from "./utils.js";
 import type { FilePatch, PlanFile, Principle, StateFile } from "./types.js";
 
 function renderPrinciple(principle: Principle): string {
@@ -65,6 +65,7 @@ function readDesiredPrinciples(state: StateFile): Principle[] {
 export function buildPlan(): PlanFile {
   const repoRoot = getRepoRoot();
   const state = readState(repoRoot);
+  const conflictsFile = readConflicts(repoRoot);
   const desired = readDesiredPrinciples(state);
   const principle_changes = desired.map((p) => ({
     action: "update" as const,
@@ -85,7 +86,7 @@ export function buildPlan(): PlanFile {
     }
   }
 
-  const conflicts: PlanFile["conflicts"] = [];
+  const conflicts: PlanFile["conflicts"] = conflictsFile?.conflicts ?? [];
   const plan: PlanFile = {
     version: 1,
     base_commit: state.repo.head_commit,

--- a/src/instrctl/plan.ts
+++ b/src/instrctl/plan.ts
@@ -1,0 +1,104 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+import { MANAGED_BEGIN, MANAGED_END, MANAGED_SECTION_HEADING } from "./constants.js";
+import { readConfig } from "./config.js";
+import { scopeIntersects } from "./scope.js";
+import { readState } from "./state.js";
+import { ensureDir, getRepoRoot, writeFileSafe } from "./utils.js";
+import type { FilePatch, PlanFile, Principle, StateFile } from "./types.js";
+
+function renderPrinciple(principle: Principle): string {
+  const strength = principle.strength === "MUST_NOT" ? "MUST NOT" : principle.strength;
+  return [
+    `<!-- instrctl:begin ${principle.id} -->`,
+    `- **${strength}** ${principle.statement}`,
+    `<!-- instrctl:end ${principle.id} -->`,
+  ].join("\n");
+}
+
+function renderSection(principles: Principle[]): string {
+  const sorted = [...principles].sort((a, b) => a.title.localeCompare(b.title));
+  const blocks = sorted.map(renderPrinciple).join("\n\n");
+  return [MANAGED_SECTION_HEADING, MANAGED_BEGIN, blocks, MANAGED_END, ""].join("\n");
+}
+
+function replaceManagedSection(original: string, rendered: string): string {
+  if (original.includes(MANAGED_BEGIN) && original.includes(MANAGED_END)) {
+    const start = original.indexOf(MANAGED_BEGIN);
+    const end = original.indexOf(MANAGED_END) + MANAGED_END.length;
+    return original.slice(0, start) + rendered + original.slice(end);
+  }
+  if (original.includes(MANAGED_SECTION_HEADING)) {
+    const [before] = original.split(MANAGED_SECTION_HEADING);
+    return `${before}${rendered}`;
+  }
+  return `${original.trim()}\n\n${rendered}`;
+}
+
+function managedContent(doc: StateFile["documents"][number], desired: Principle[]): string {
+  const applicable = desired.filter((p) => scopeIntersects(p.scope, doc.docScope));
+  return renderSection(applicable);
+}
+
+function unifiedDiff(pathName: string, before: string, after: string): string {
+  if (before === after) return "";
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "instrctl-"));
+  const left = path.join(tmpDir, "before.txt");
+  const right = path.join(tmpDir, "after.txt");
+  fs.writeFileSync(left, before, "utf8");
+  fs.writeFileSync(right, after, "utf8");
+  const diff = spawnSync("git", ["diff", "--no-index", "--", left, right], {
+    encoding: "utf8",
+  });
+  const output = (diff.stdout || "") + (diff.stderr || "");
+  return output.replaceAll(left, pathName).replaceAll(right, pathName);
+}
+
+function readDesiredPrinciples(state: StateFile): Principle[] {
+  const config = readConfig(state.repo.root);
+  if (config && config.principles.length) return config.principles;
+  return state.principles;
+}
+
+export function buildPlan(): PlanFile {
+  const repoRoot = getRepoRoot();
+  const state = readState(repoRoot);
+  const desired = readDesiredPrinciples(state);
+  const principle_changes = desired.map((p) => ({
+    action: "update" as const,
+    id: p.id,
+    after_hash: p.fingerprint,
+  }));
+
+  const file_patches: FilePatch[] = [];
+
+  for (const doc of state.documents) {
+    const docPath = path.join(repoRoot, doc.path);
+    const before = fs.readFileSync(docPath, "utf8");
+    const rendered = managedContent(doc, desired);
+    const after = replaceManagedSection(before, rendered);
+    const patch = unifiedDiff(doc.path, before, after);
+    if (patch) {
+      file_patches.push({ path: doc.path, patch_unified: patch });
+    }
+  }
+
+  const conflicts: PlanFile["conflicts"] = [];
+  const plan: PlanFile = {
+    version: 1,
+    base_commit: state.repo.head_commit,
+    principle_changes,
+    file_patches,
+    conflicts,
+    validation: {
+      patch_constraints_ok: true,
+      roundtrip_ok: true,
+    },
+  };
+  const outPath = path.join(repoRoot, ".instrctl", "plan.json");
+  ensureDir(path.dirname(outPath));
+  writeFileSafe(outPath, JSON.stringify(plan, null, 2));
+  return plan;
+}

--- a/src/instrctl/plan.ts
+++ b/src/instrctl/plan.ts
@@ -31,8 +31,9 @@ function replaceManagedSection(original: string, rendered: string): string {
     return original.slice(0, start) + rendered + original.slice(end);
   }
   if (original.includes(MANAGED_SECTION_HEADING)) {
-    const [before] = original.split(MANAGED_SECTION_HEADING);
-    return `${before}${rendered}`;
+    const [before, ...afterParts] = original.split(MANAGED_SECTION_HEADING);
+    const after = afterParts.join(MANAGED_SECTION_HEADING);
+    return `${before}${rendered}${after}`;
   }
   return `${original.trim()}\n\n${rendered}`;
 }

--- a/src/instrctl/plan.ts
+++ b/src/instrctl/plan.ts
@@ -86,7 +86,10 @@ export function buildPlan(): PlanFile {
     }
   }
 
-  const conflicts: PlanFile["conflicts"] = conflictsFile?.conflicts ?? [];
+  const conflicts: PlanFile["conflicts"] = (conflictsFile?.conflicts ?? []).map((conflict) => ({
+    conflict_id: conflict.conflict_id,
+    blocking: Boolean(conflict.blocking),
+  }));
   const plan: PlanFile = {
     version: 1,
     base_commit: state.repo.head_commit,

--- a/src/instrctl/scope.ts
+++ b/src/instrctl/scope.ts
@@ -1,0 +1,35 @@
+import path from "path";
+
+export function inferDocScope(repoRoot: string, docPath: string, docText: string): string[] {
+  const relative = path.relative(repoRoot, docPath).replace(/\\/g, "/");
+  const frontmatterMatch = docText.match(/^---\n([\s\S]*?)\n---/);
+  if (frontmatterMatch) {
+    const content = frontmatterMatch[1];
+    const scopeMatch = content.match(/scope:\s*\[([^\]]*)\]/);
+    if (scopeMatch) {
+      const parts = scopeMatch[1]
+        .split(",")
+        .map((p) => p.replace(/['"\s]/g, "").trim())
+        .filter(Boolean);
+      if (parts.length) return parts;
+    }
+  }
+  const dir = path.dirname(relative);
+  if (dir === ".") return ["repo/**"];
+  return [`${dir}/**`];
+}
+
+export function scopeIntersects(a: string[], b: string[]): boolean {
+  for (const pa of a) {
+    for (const pb of b) {
+      if (pa === "repo/**" || pb === "repo/**") return true;
+      const simpleA = pa.replace("/**", "");
+      const simpleB = pb.replace("/**", "");
+      if (simpleA === simpleB) return true;
+      if (simpleA && simpleB && (simpleA.startsWith(simpleB) || simpleB.startsWith(simpleA))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/src/instrctl/state.ts
+++ b/src/instrctl/state.ts
@@ -1,0 +1,70 @@
+import fs from "fs";
+import path from "path";
+import { buildConflicts } from "./conflicts.js";
+import { discoverDocuments } from "./discovery.js";
+import { extractPrinciples } from "./extract.js";
+import { ensureDir, getHeadCommit, getRepoRoot, readFileSafe, writeFileSafe } from "./utils.js";
+import type { ConflictsFile, StateFile } from "./types.js";
+
+async function buildState(): Promise<StateFile> {
+  const repoRoot = getRepoRoot();
+  const head = getHeadCommit();
+  const documents = discoverDocuments(repoRoot);
+  const principles: StateFile["principles"] = [];
+  const occurrences: StateFile["occurrences"] = [];
+
+  for (const doc of documents) {
+    const content = readFileSafe(path.join(repoRoot, doc.path));
+    const extracted = await extractPrinciples(doc.path, content, doc.docScope);
+    principles.push(...extracted.principles);
+    occurrences.push(...extracted.occurrences);
+  }
+
+  return {
+    version: 1,
+    repo: { root: repoRoot, head_commit: head },
+    documents,
+    principles,
+    occurrences,
+  };
+}
+
+export async function writeStateFiles(): Promise<{
+  state: StateFile;
+  conflicts: ConflictsFile;
+}> {
+  const state = await buildState();
+  const conflicts = buildConflicts(state.repo.head_commit, state.principles);
+  const instrctlDir = path.join(state.repo.root, ".instrctl");
+  ensureDir(instrctlDir);
+  writeFileSafe(path.join(instrctlDir, "state.json"), JSON.stringify(state, null, 2));
+  writeFileSafe(path.join(instrctlDir, "conflicts.json"), JSON.stringify(conflicts, null, 2));
+
+  const mdLines = [
+    "# Conflicts",
+    "",
+    `Base commit: ${state.repo.head_commit}`,
+    "",
+  ];
+  if (!conflicts.conflicts.length) {
+    mdLines.push("No conflicts detected.");
+  } else {
+    mdLines.push("| ID | Type | Severity | Blocking | Principle IDs | Explanation |", "|---|---|---|---|---|---|");
+    for (const conflict of conflicts.conflicts) {
+      mdLines.push(
+        `| ${conflict.conflictId} | ${conflict.type} | ${conflict.severity} | ${conflict.blocking} | ${conflict.principleIds.join(", ")} | ${conflict.explanation} |`,
+      );
+    }
+  }
+  writeFileSafe(path.join(instrctlDir, "conflicts.md"), mdLines.join("\n"));
+  return { state, conflicts };
+}
+
+export function readState(repoRoot: string): StateFile {
+  const file = path.join(repoRoot, ".instrctl", "state.json");
+  if (!fs.existsSync(file)) {
+    throw new Error(".instrctl/state.json missing; run instrctl init first.");
+  }
+  const content = fs.readFileSync(file, "utf8");
+  return JSON.parse(content) as StateFile;
+}

--- a/src/instrctl/types.ts
+++ b/src/instrctl/types.ts
@@ -1,0 +1,113 @@
+import type { Stats } from "fs";
+
+export type Dialect =
+  | "generic"
+  | "claude"
+  | "agents"
+  | "cursor"
+  | "bugbot"
+  | "skills"
+  | "custom";
+
+export interface DocumentDescriptor {
+  path: string;
+  dialect: Dialect;
+  docScope: string[];
+  sha256: string;
+}
+
+export interface PrincipleSource {
+  doc: string;
+  span: { startLine: number; endLine: number };
+  rawTextHash: string;
+}
+
+export interface Principle {
+  id: string;
+  title: string;
+  strength: "MUST" | "SHOULD" | "MAY" | "MUST_NOT";
+  statement: string;
+  scope: string[];
+  tags?: string[];
+  rationale?: string;
+  examples?: string[];
+  sources?: PrincipleSource[];
+  fingerprint?: string;
+}
+
+export interface Occurrence {
+  principleId: string;
+  doc: string;
+  span: { startLine: number; endLine: number };
+  anchor?: string;
+}
+
+export interface StateFile {
+  version: number;
+  repo: {
+    root: string;
+    head_commit: string;
+  };
+  documents: DocumentDescriptor[];
+  principles: Principle[];
+  occurrences: Occurrence[];
+  llm?: Record<string, unknown>;
+}
+
+export interface ConflictEvidence {
+  doc: string;
+  span: { startLine: number; endLine: number };
+}
+
+export interface Conflict {
+  conflictId: string;
+  type:
+    | "DUPLICATE"
+    | "CONTRADICTION"
+    | "PARAMETER_MISMATCH"
+    | "OVERRIDE_MISSING"
+    | "AMBIGUOUS_SCOPE";
+  severity: "LOW" | "MEDIUM" | "HIGH";
+  topic: string;
+  principleIds: string[];
+  overlappingScope: string[];
+  evidence: ConflictEvidence[];
+  explanation: string;
+  suggestedResolution: string;
+  blocking: boolean;
+}
+
+export interface ConflictsFile {
+  version: number;
+  base_commit: string;
+  conflicts: Conflict[];
+}
+
+export interface PlanChange {
+  action: "create" | "update" | "delete";
+  id: string;
+  before_hash?: string;
+  after_hash?: string;
+}
+
+export interface FilePatch {
+  path: string;
+  patch_unified: string;
+}
+
+export interface PlanFile {
+  version: number;
+  base_commit: string;
+  principle_changes: PlanChange[];
+  file_patches: FilePatch[];
+  conflicts: { conflict_id: string; blocking: boolean }[];
+  validation: {
+    patch_constraints_ok: boolean;
+    roundtrip_ok: boolean;
+  };
+}
+
+export interface RepoEntry {
+  path: string;
+  stats: Stats;
+}

--- a/src/instrctl/utils.ts
+++ b/src/instrctl/utils.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import { execSync } from "child_process";
 import type { ConflictsFile } from "./types.js";
-import { matchAny, pathMatches } from "./matcher.js";
+import { matchAny } from "./matcher.js";
 
 export function sha256(content: string): string {
   return crypto.createHash("sha256").update(content).digest("hex");

--- a/src/instrctl/utils.ts
+++ b/src/instrctl/utils.ts
@@ -1,0 +1,85 @@
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import { execSync } from "child_process";
+
+export function sha256(content: string): string {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+export function ensureDir(dir: string) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function readFileSafe(filePath: string): string {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+export function writeFileSafe(filePath: string, content: string) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+export function getRepoRoot(): string {
+  try {
+    const root = execSync("git rev-parse --show-toplevel", {
+      encoding: "utf8",
+    }).trim();
+    return root;
+  } catch {
+    return process.cwd();
+  }
+}
+
+export function getHeadCommit(): string {
+  try {
+    return execSync("git rev-parse HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+export function relativePath(root: string, target: string): string {
+  return path.relative(root, target) || path.basename(target);
+}
+
+export function idFromRandom(): string {
+  return `P-${crypto.randomBytes(4).toString("hex").toUpperCase()}`;
+}
+
+export function normalizeStatement(statement: string): string {
+  return statement
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function inferenceTitle(statement: string): string {
+  const words = statement.split(/\s+/).slice(0, 6).join(" ");
+  return words.length ? words : "Principle";
+}
+
+export function repoEntries(root: string, exclude: string[] = []): string[] {
+  const entries: string[] = [];
+  const queue: string[] = [root];
+  while (queue.length) {
+    const current = queue.pop();
+    if (!current) continue;
+    const stat = fs.statSync(current);
+    if (stat.isDirectory()) {
+      const relative = path.relative(root, current).replace(/\\/g, "/");
+      if (relative && exclude.some((pattern) => relative.startsWith(pattern.replace("/**", "")))) {
+        continue;
+      }
+      for (const child of fs.readdirSync(current)) {
+        queue.push(path.join(current, child));
+      }
+    } else {
+      entries.push(current);
+    }
+  }
+  return entries;
+}

--- a/src/instrctl/utils.ts
+++ b/src/instrctl/utils.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import { execSync } from "child_process";
 import type { ConflictsFile } from "./types.js";
+import { matchAny, pathMatches } from "./matcher.js";
 
 export function sha256(content: string): string {
   return crypto.createHash("sha256").update(content).digest("hex");
@@ -72,7 +73,7 @@ export function repoEntries(root: string, exclude: string[] = []): string[] {
     const stat = fs.statSync(current);
     if (stat.isDirectory()) {
       const relative = path.relative(root, current).replace(/\\/g, "/");
-      if (relative && exclude.some((pattern) => relative.startsWith(pattern.replace("/**", "")))) {
+      if (relative && matchAny(`${relative}/`, exclude)) {
         continue;
       }
       for (const child of fs.readdirSync(current)) {

--- a/src/instrctl/utils.ts
+++ b/src/instrctl/utils.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import { execSync } from "child_process";
+import type { ConflictsFile } from "./types.js";
 
 export function sha256(content: string): string {
   return crypto.createHash("sha256").update(content).digest("hex");
@@ -82,4 +83,11 @@ export function repoEntries(root: string, exclude: string[] = []): string[] {
     }
   }
   return entries;
+}
+
+export function readConflicts(repoRoot: string = getRepoRoot()): ConflictsFile | null {
+  const conflictPath = path.join(repoRoot, ".instrctl", "conflicts.json");
+  if (!fs.existsSync(conflictPath)) return null;
+  const content = fs.readFileSync(conflictPath, "utf8");
+  return JSON.parse(content) as ConflictsFile;
 }

--- a/src/lib/env-schema.ts
+++ b/src/lib/env-schema.ts
@@ -21,6 +21,8 @@ const envSchema = z.object({
   LINEAR_CLIENT_ID: z.string().default("a20b70eadc1cce2121089f70402351d6"),
   GH_TOKEN: z.string().optional(),
   ANTHROPIC_TOKEN: z.string().optional(),
+  BAZ_LLM_TOKEN: z.string().optional(),
+  BAZ_TOKEN: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/test/instrctl/conflicts.test.ts
+++ b/test/instrctl/conflicts.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildConflicts } from "../../src/instrctl/conflicts.js";
+import type { Principle } from "../../src/instrctl/types.js";
+
+test("buildConflicts surfaces duplicates and contradictions", () => {
+  const principles: Principle[] = [
+    {
+      id: "P-1",
+      title: "Use yarn",
+      strength: "MUST",
+      statement: "Use yarn for installs",
+      scope: ["repo/**"],
+    },
+    {
+      id: "P-2",
+      title: "Use yarn duplicate",
+      strength: "MUST",
+      statement: "Use yarn for installs",
+      scope: ["repo/**"],
+    },
+    {
+      id: "P-3",
+      title: "Avoid yarn",
+      strength: "MUST_NOT",
+      statement: "Use yarn for installs",
+      scope: ["repo/**"],
+    },
+  ];
+
+  const conflicts = buildConflicts("abc123", principles);
+  assert.equal(conflicts.conflicts.length, 2);
+  const duplicate = conflicts.conflicts.find((c) => c.type === "DUPLICATE");
+  const contradiction = conflicts.conflicts.find((c) => c.type === "CONTRADICTION");
+  assert.ok(duplicate);
+  assert.ok(contradiction);
+  assert.equal(contradiction?.blocking, true);
+});

--- a/test/instrctl/discovery.test.ts
+++ b/test/instrctl/discovery.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { discoverDocuments } from "../../src/instrctl/discovery.js";
+import { DEFAULT_EXCLUDE, DEFAULT_INCLUDE } from "../../src/instrctl/constants.js";
+
+test("discoverDocuments finds known instruction docs and skips excluded folders", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "instrctl-discovery-"));
+  const agentPath = path.join(temp, "agents.md");
+  const cursorRules = path.join(temp, ".cursor", "rules.md");
+  fs.mkdirSync(path.dirname(cursorRules), { recursive: true });
+  fs.writeFileSync(agentPath, "- **MUST** follow the plan", "utf8");
+  fs.writeFileSync(cursorRules, "- **MAY** adjust prompts", "utf8");
+  fs.mkdirSync(path.join(temp, "node_modules"));
+  fs.writeFileSync(path.join(temp, "node_modules", "ignored.md"), "- **MUST** be skipped", "utf8");
+
+  const docs = discoverDocuments(temp, { include: DEFAULT_INCLUDE, exclude: DEFAULT_EXCLUDE });
+  const paths = docs.map((d) => d.path).sort();
+  assert.deepEqual(paths, [".cursor/rules.md", "agents.md"]);
+  assert.ok(docs.every((doc) => doc.docScope.length > 0 && doc.sha256));
+});

--- a/test/instrctl/extract.test.ts
+++ b/test/instrctl/extract.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { extractPrinciples } from "../../src/instrctl/extract.js";
+
+test("extractPrinciples pulls modal statements with metadata", async () => {
+  const content = [
+    "Random intro",
+    "- **MUST** keep changes minimal.",
+    "- SHOULD consider edge cases",
+    "- optional note without modal",
+    "- **MUST NOT** leak secrets",
+  ].join("\n");
+
+  const { principles, occurrences } = await extractPrinciples("agents.md", content, ["repo/**"]);
+  assert.equal(principles.length, 3);
+  assert.equal(occurrences.length, 3);
+  assert.equal(principles[0].strength, "MUST");
+  assert.equal(principles[0].statement, "keep changes minimal.");
+  assert.equal(principles[2].strength, "MUST_NOT");
+  assert.ok(principles[0].fingerprint);
+  assert.deepEqual(principles[0].scope, ["repo/**"]);
+});

--- a/test/instrctl/matcher.test.ts
+++ b/test/instrctl/matcher.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { docDialect, globToRegex, pathMatches } from "../../src/instrctl/matcher.js";
+
+void test("globToRegex matches double star and single star patterns", () => {
+  const regex = globToRegex("docs/**/file*.md");
+  assert.ok(regex.test("docs/a/file1.md"));
+  assert.ok(regex.test("docs/a/b/fileX.md"));
+  assert.ok(!regex.test("docs/file.md"));
+});
+
+void test("pathMatches respects include and exclude globs", () => {
+  const include = ["**/*.md"];
+  const exclude = ["node_modules/**", "dist/**"];
+  assert.ok(pathMatches("notes/agents.md", include, exclude));
+  assert.ok(!pathMatches("node_modules/agents.md", include, exclude));
+  assert.ok(!pathMatches("dist/agents.md", include, exclude));
+});
+
+void test("docDialect infers known dialect names", () => {
+  assert.equal(docDialect("CLAUDE.md"), "claude");
+  assert.equal(docDialect("agents.md"), "agents");
+  assert.equal(docDialect("skills.md"), "skills");
+  assert.equal(docDialect("cursor-rules.txt"), "cursor");
+  assert.equal(docDialect(".cursor/rules.yaml"), "cursor");
+  assert.equal(docDialect("misc.txt"), "generic");
+});

--- a/test/instrctl/plan-integration.test.ts
+++ b/test/instrctl/plan-integration.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { buildPlan } from "../../src/instrctl/plan.js";
+import { writeStateFiles } from "../../src/instrctl/state.js";
+
+function createFixtureRepo(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "instrctl-plan-"));
+  fs.writeFileSync(
+    path.join(root, "CLAUDE.md"),
+    [
+      "# Instructions",
+      "- **MUST** follow the release checklist",
+      "- **MUST NOT** leak credentials",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  fs.mkdirSync(path.join(root, "frontend"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "frontend", "agents.md"),
+    [
+      "## Agent Rules",
+      "- **SHOULD** add screenshots for UI changes",
+      "- **MAY** adjust copy without review",
+    ].join("\n"),
+    "utf8",
+  );
+  return root;
+}
+
+test("writeStateFiles and buildPlan generate managed patches", async () => {
+  const originalCwd = process.cwd();
+  const fixture = createFixtureRepo();
+  process.chdir(fixture);
+  try {
+    const { state, conflicts } = await writeStateFiles();
+    assert.equal(state.documents.length, 2);
+    assert.equal(conflicts.conflicts.length, 0);
+    const plan = buildPlan();
+    assert.ok(plan.file_patches.length >= 2);
+    const planPath = path.join(fixture, ".instrctl", "plan.json");
+    const persisted = JSON.parse(fs.readFileSync(planPath, "utf8"));
+    assert.ok(persisted.file_patches.every((p: { patch_unified: string }) => p.patch_unified.includes("Managed Principles")));
+  } finally {
+    process.chdir(originalCwd);
+    fs.rmSync(fixture, { recursive: true, force: true });
+  }
+});

--- a/test/instrctl/scope.test.ts
+++ b/test/instrctl/scope.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { inferDocScope, scopeIntersects } from "../../src/instrctl/scope.js";
+
+test("inferDocScope falls back to repo or folder scope", () => {
+  const repoRoot = "/tmp/repo";
+  const rootDoc = inferDocScope(repoRoot, path.join(repoRoot, "CLAUDE.md"), "");
+  assert.deepEqual(rootDoc, ["repo/**"]);
+  const nestedDoc = inferDocScope(repoRoot, path.join(repoRoot, "frontend", "agents.md"), "");
+  assert.deepEqual(nestedDoc, ["frontend/**"]);
+});
+
+test("inferDocScope honors frontmatter scope overrides", () => {
+  const repoRoot = "/tmp/repo";
+  const content = "---\ninstrctl:\n  scope: ['frontend/**', 'docs/**']\n---\nbody";
+  const scoped = inferDocScope(repoRoot, path.join(repoRoot, "README.md"), content);
+  assert.deepEqual(scoped, ["frontend/**", "docs/**"]);
+});
+
+test("scopeIntersects handles repo wildcards and nested overlaps", () => {
+  assert.equal(scopeIntersects(["repo/**"], ["docs/**"]), true);
+  assert.equal(scopeIntersects(["frontend/**"], ["frontend/ui/**"]), true);
+  assert.equal(scopeIntersects(["frontend/**"], ["backend/**"]), false);
+});


### PR DESCRIPTION
# User description
## Summary
- document current instrctl limitations and token handling in README
- allow Baz token environment variables as fallbacks for Anthropic LLM extraction

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941d20de09c832ba6552cd18cc66aa9)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
createInstrctlCommand_("createInstrctlCommand"):::added
applyPlan_("applyPlan"):::added
buildPlan_("buildPlan"):::added
writeStateFiles_("writeStateFiles"):::added
readState_("readState"):::added
readPlan_("readPlan"):::added
validatePatchAgainstState_("validatePatchAgainstState"):::added
applyPatch_("applyPatch"):::added
buildConflicts_("buildConflicts"):::added
ensureDir_("ensureDir"):::added
writeFileSafe_("writeFileSafe"):::added
buildState_("buildState"):::added
discoverDocuments_("discoverDocuments"):::added
getRepoRoot_("getRepoRoot"):::added
getHeadCommit_("getHeadCommit"):::added
readFileSafe_("readFileSafe"):::added
extractPrinciples_("extractPrinciples"):::added
createInstrctlCommand_ -- "Adds CLI command to apply generated plan to repository." --> applyPlan_
createInstrctlCommand_ -- "Adds CLI command to compute plan aligning documents with principles." --> buildPlan_
createInstrctlCommand_ -- "Adds CLI command to discover documents and generate state files." --> writeStateFiles_
applyPlan_ -- "Reads current repository state before applying plan patches." --> readState_
applyPlan_ -- "Reads previously generated plan file before applying patches." --> readPlan_
applyPlan_ -- "Validates patches are within allowed managed regions before applying." --> validatePatchAgainstState_
applyPlan_ -- "Applies each validated patch to the repository files." --> applyPatch_
buildPlan_ -- "Reads current repository state to build alignment plan." --> readState_
buildPlan_ -- "Detects conflicts among principles when building the plan." --> buildConflicts_
buildPlan_ -- "Ensures .instrctl directory exists before writing plan files." --> ensureDir_
buildPlan_ -- "Writes the generated plan.json file to disk safely." --> writeFileSafe_
writeStateFiles_ -- "Builds current repository state including documents and principles." --> buildState_
writeStateFiles_ -- "Detects conflicts among principles in the current state." --> buildConflicts_
writeStateFiles_ -- "Ensures .instrctl directory exists before writing state files." --> ensureDir_
writeStateFiles_ -- "Writes state.json and conflicts.json files safely to disk." --> writeFileSafe_
buildState_ -- "Discovers instruction documents in the repository." --> discoverDocuments_
buildState_ -- "Determines repository root directory for state building." --> getRepoRoot_
buildState_ -- "Gets current HEAD commit hash for state metadata." --> getHeadCommit_
buildState_ -- "Reads content of each discovered document safely." --> readFileSafe_
buildState_ -- "Extracts principles and occurrences from document content." --> extractPrinciples_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Implement the core <code>instrctl</code> command-line tool to manage and synchronize instruction documents across a repository, enabling automated extraction of principles, conflict detection, and generation of patches. Integrate Anthropic LLM for principle extraction with fallback token handling, and provide comprehensive documentation on the tool's functionality and current limitations.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/84?tool=ast&topic=LLM+%26+Docs>LLM & Docs</a>
        </td><td>Integrate Anthropic LLM for principle extraction, allowing <code>BAZ_LLM_TOKEN</code> and <code>BAZ_TOKEN</code> as environment variable fallbacks, and document the <code>instrctl</code> tool's execution specification, usage, and current limitations.<details><summary>Modified files (4)</summary><ul><li>src/lib/env-schema.ts</li>
<li>docs/instrctl-execution-spec.md</li>
<li>README.md</li>
<li>src/instrctl/extract.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrod@baz.co</td><td>docs-Improve-GH-PAT-pe...</td><td>December 15, 2025</td></tr>
<tr><td>guyeisenkot</td><td>docs-Enhance-README-wi...</td><td>December 04, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/84?tool=ast&topic=instrctl+Core>instrctl Core</a>
        </td><td>Implement the foundational logic for the <code>instrctl</code> tool, including its CLI commands, document discovery, state management, principle extraction, conflict detection, plan generation, and patch application.<details><summary>Modified files (21)</summary><ul><li>test/instrctl/plan-integration.test.ts</li>
<li>test/instrctl/matcher.test.ts</li>
<li>test/instrctl/extract.test.ts</li>
<li>test/instrctl/discovery.test.ts</li>
<li>src/instrctl/scope.ts</li>
<li>src/instrctl/matcher.ts</li>
<li>src/instrctl/conflicts.ts</li>
<li>package.json</li>
<li>src/instrctl/plan.ts</li>
<li>src/instrctl/utils.ts</li>
<li>src/instrctl/types.ts</li>
<li>src/instrctl/state.ts</li>
<li>src/instrctl/constants.ts</li>
<li>src/instrctl/discovery.ts</li>
<li>src/commands/instrctl.ts</li>
<li>src/instrctl/apply.ts</li>
<li>src/instrctl/extract.ts</li>
<li>src/instrctl/config.ts</li>
<li>test/instrctl/conflicts.test.ts</li>
<li>src/index.ts</li>
<li>test/instrctl/scope.test.ts</li></ul></details><details><summary>Checks (2)</summary><ul><li>PR / build-test</li>
<li>PR / lint</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>internal-baz-ci-app[bot]</td><td>chore-main-release-0.3...</td><td>December 16, 2025</td></tr>
<tr><td>anton.gruebel@gmail.com</td><td>feat-add-option-to-Cha...</td><td>December 14, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/84?tool=ast>(Baz)</a>.