### PR TITLE
feat: stop agent after sending prompt

### DIFF
--- a/src/lib/chat-stream.ts
+++ b/src/lib/chat-stream.ts
@@ -9,11 +9,20 @@ export interface StreamHandlerCallbacks {
     toolCalls: ChatToolCall[],
     isFirst: boolean,
   ) => void;
+  onAbort?: () => void;
+}
+
+export class StreamAbortError extends Error {
+  constructor() {
+    super("Stream aborted by user");
+    this.name = "StreamAbortError";
+  }
 }
 
 export async function processStream(
   request: CheckoutChatRequest,
   callbacks: StreamHandlerCallbacks,
+  abortSignal?: AbortSignal,
 ): Promise<void> {
   let accumulatedResponse = "";
   let toolCalls: ChatToolCall[] = [];
@@ -25,77 +34,105 @@ export async function processStream(
     isFirstUpdate = false;
   };
 
-  for await (const chunk of streamChatResponse(request)) {
-    if (chunk.conversationId) {
-      callbacks.onConversationId(chunk.conversationId);
-    }
+  try {
+    for await (const chunk of streamChatResponse(request, abortSignal)) {
+      // Check if aborted before processing chunk
+      if (abortSignal?.aborted) {
+        callbacks.onAbort?.();
+        throw new StreamAbortError();
+      }
 
-    if (chunk.toolCall) {
-      const { toolName, toolArgs, toolCallId, message } = chunk.toolCall;
+      if (chunk.conversationId) {
+        callbacks.onConversationId(chunk.conversationId);
+      }
 
-      if (toolCallId && !message) {
-        // New tool call with ID
-        toolCalls = [
-          ...toolCalls,
-          { id: toolCallId, toolName, toolArgs, message },
-        ];
-      } else {
-        // Update message - prefer matching by toolCallId if available
-        let targetIndex = -1;
-        if (toolCallId) {
-          targetIndex = toolCalls.findIndex((tc) => tc.id === toolCallId);
+      if (chunk.toolCall) {
+        const { toolName, toolArgs, toolCallId, message } = chunk.toolCall;
+
+        if (toolCallId && !message) {
+          // New tool call with ID
+          toolCalls = [
+            ...toolCalls,
+            { id: toolCallId, toolName, toolArgs, message },
+          ];
+        } else {
+          // Update message - prefer matching by toolCallId if available
+          let targetIndex = -1;
+          if (toolCallId) {
+            targetIndex = toolCalls.findIndex((tc) => tc.id === toolCallId);
+          }
+          // Fallback: match by toolName + toolArgs
+          if (targetIndex === -1) {
+            const argsKey = JSON.stringify(toolArgs);
+            targetIndex = toolCalls.findIndex(
+              (tc) =>
+                !tc.result &&
+                tc.toolName === toolName &&
+                JSON.stringify(tc.toolArgs) === argsKey,
+            );
+          }
+          // Final fallback: first pending without message
+          const finalIndex =
+            targetIndex !== -1
+              ? targetIndex
+              : toolCalls.findIndex((tc) => !tc.result && !tc.message);
+          if (finalIndex !== -1) {
+            toolCalls = toolCalls.map((tc, i) =>
+              i === finalIndex ? { ...tc, message } : tc,
+            );
+          }
         }
-        // Fallback: match by toolName + toolArgs
-        if (targetIndex === -1) {
-          const argsKey = JSON.stringify(toolArgs);
-          targetIndex = toolCalls.findIndex(
-            (tc) =>
-              !tc.result &&
-              tc.toolName === toolName &&
-              JSON.stringify(tc.toolArgs) === argsKey,
-          );
-        }
-        // Final fallback: first pending without message
+
+        update();
+      }
+
+      if (chunk.toolResult) {
+        const { toolCallId, content } = chunk.toolResult;
+        // Find by ID first, fallback to last pending
+        const targetIndex = toolCalls.findIndex((tc) => tc.id === toolCallId);
         const finalIndex =
           targetIndex !== -1
             ? targetIndex
-            : toolCalls.findIndex((tc) => !tc.result && !tc.message);
+            : toolCalls.findLastIndex((tc) => !tc.result);
+
         if (finalIndex !== -1) {
+          // Create new object to trigger React re-render
           toolCalls = toolCalls.map((tc, i) =>
-            i === finalIndex ? { ...tc, message } : tc,
+            i === finalIndex ? { ...tc, result: content } : tc,
           );
+          update();
         }
       }
 
-      update();
-    }
-
-    if (chunk.toolResult) {
-      const { toolCallId, content } = chunk.toolResult;
-      // Find by ID first, fallback to last pending
-      const targetIndex = toolCalls.findIndex((tc) => tc.id === toolCallId);
-      const finalIndex =
-        targetIndex !== -1
-          ? targetIndex
-          : toolCalls.findLastIndex((tc) => !tc.result);
-
-      if (finalIndex !== -1) {
-        // Create new object to trigger React re-render
-        toolCalls = toolCalls.map((tc, i) =>
-          i === finalIndex ? { ...tc, result: content } : tc,
-        );
+      if (chunk.content) {
+        accumulatedResponse += chunk.content;
+        // Only notify on first TEXT content (not tool calls)
+        if (!hasReceivedTextContent) {
+          hasReceivedTextContent = true;
+          callbacks.onFirstTextContent();
+        }
         update();
       }
     }
-
-    if (chunk.content) {
-      accumulatedResponse += chunk.content;
-      // Only notify on first TEXT content (not tool calls)
-      if (!hasReceivedTextContent) {
-        hasReceivedTextContent = true;
-        callbacks.onFirstTextContent();
+  } catch (error) {
+    // Check if this is an axios cancellation error or our abort error
+    if (
+      error &&
+      typeof error === "object" &&
+      "name" in error &&
+      (error.name === "CanceledError" || error instanceof StreamAbortError)
+    ) {
+      // Call onAbort to reset loading state
+      if (callbacks.onAbort) {
+        callbacks.onAbort();
       }
-      update();
+      // Ensure we throw StreamAbortError for consistent handling
+      if (!(error instanceof StreamAbortError)) {
+        throw new StreamAbortError();
+      }
+      throw error;
     }
+    // Re-throw other errors
+    throw error;
   }
 }

--- a/src/lib/clients/baz.ts
+++ b/src/lib/clients/baz.ts
@@ -20,6 +20,7 @@ import {
   Requirement,
   SpecReview,
 } from "../providers/types.js";
+import { StreamAbortError } from "../chat-stream.js";
 
 const COMMENTS_URL = `${env.BAZ_BASE_URL}/api/v1/comments`;
 const PULL_REQUESTS_URL = `${env.BAZ_BASE_URL}/api/v2/changes`;
@@ -503,7 +504,7 @@ export async function* streamChatResponse(
     for await (const chunk of response.data) {
       // Check if aborted before processing chunk
       if (abortSignal?.aborted) {
-        throw new Error("StreamAbortError");
+        throw new StreamAbortError();
       }
 
       buffer += chunk.toString();

--- a/src/lib/clients/baz.ts
+++ b/src/lib/clients/baz.ts
@@ -503,7 +503,7 @@ export async function* streamChatResponse(
     for await (const chunk of response.data) {
       // Check if aborted before processing chunk
       if (abortSignal?.aborted) {
-        break;
+        throw new Error("StreamAbortError");
       }
 
       buffer += chunk.toString();

--- a/src/lib/clients/baz.ts
+++ b/src/lib/clients/baz.ts
@@ -487,6 +487,7 @@ function* processStreamMessage(
 
 export async function* streamChatResponse(
   request: CheckoutChatRequest,
+  abortSignal?: AbortSignal,
 ): AsyncGenerator<ChatStreamChunk, void, unknown> {
   try {
     const response = await axiosClient.post(CHAT_URL, request, {
@@ -494,11 +495,17 @@ export async function* streamChatResponse(
         "Content-Type": "application/json",
       },
       responseType: "stream",
+      signal: abortSignal,
     });
 
     let buffer = "";
 
     for await (const chunk of response.data) {
+      // Check if aborted before processing chunk
+      if (abortSignal?.aborted) {
+        break;
+      }
+
       buffer += chunk.toString();
       const lines = buffer.split("\n");
       buffer = lines.pop() || "";
@@ -524,6 +531,16 @@ export async function* streamChatResponse(
       }
     }
   } catch (error: unknown) {
+    // Don't log abort errors as errors - they're expected
+    if (
+      error &&
+      typeof error === "object" &&
+      "name" in error &&
+      error.name === "CanceledError"
+    ) {
+      logger.debug("Chat stream aborted by user");
+      throw error; // Re-throw so processStream can handle it
+    }
     logger.error({ error }, "Error streaming chat response");
     throw error;
   }

--- a/src/pages/IssueBrowser.tsx
+++ b/src/pages/IssueBrowser.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useMemo, useRef } from "react";
 import { Box } from "ink";
 import { Issue, IssueContext } from "../issues/types.js";
 import { getIssueHandler } from "../issues/registry.js";
@@ -12,7 +12,7 @@ import {
 import type { Discussion } from "../lib/providers/types.js";
 import { RepoWriteAccess } from "../lib/providers/index.js";
 import { useAppMode } from "../lib/config/index.js";
-import { processStream } from "../lib/chat-stream.js";
+import { processStream, StreamAbortError } from "../lib/chat-stream.js";
 
 interface IssueBrowserProps {
   issues: Issue[];
@@ -43,6 +43,8 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
   const [repoWriteAccess, setRepoWriteAccess] =
     useState<RepoWriteAccess>(writeAccess);
   const [isLoading, setIsLoading] = useState(false);
+  const [isResponseActive, setIsResponseActive] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
   const appMode = useAppMode();
 
   const currentIssue = issues[currentIndex];
@@ -122,37 +124,70 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
       setChatMessages((prev) => [...prev, { role: "user", content: message }]);
       setIsLoading(true);
 
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+      setIsResponseActive(true);
+
       try {
         const request = await buildChatRequest(
           message,
           currentIssue,
           conversationId,
         );
-        await processStream(request, {
-          onConversationId: setConversationId,
-          onFirstTextContent: () => setIsLoading(false),
-          onUpdate: (content, toolCalls, isFirst) => {
-            if (isFirst) {
-              setChatMessages((prev) => [
-                ...prev,
-                { role: "assistant", content, toolCalls },
-              ]);
-            } else {
-              setChatMessages((prev) => {
-                const updated = [...prev];
-                updated[updated.length - 1] = {
-                  role: "assistant",
-                  content,
-                  toolCalls,
-                };
-                return updated;
-              });
-            }
+        await processStream(
+          request,
+          {
+            onConversationId: setConversationId,
+            onFirstTextContent: () => setIsLoading(false),
+            onUpdate: (content, toolCalls, isFirst) => {
+              if (isFirst) {
+                setChatMessages((prev) => [
+                  ...prev,
+                  { role: "assistant", content, toolCalls },
+                ]);
+              } else {
+                setChatMessages((prev) => {
+                  const updated = [...prev];
+                  updated[updated.length - 1] = {
+                    role: "assistant",
+                    content,
+                    toolCalls,
+                  };
+                  return updated;
+                });
+              }
+            },
+            onAbort: () => {
+              setIsLoading(false);
+              setIsResponseActive(false);
+            },
           },
-        });
+          abortController.signal,
+        );
+        setIsResponseActive(false);
+        abortControllerRef.current = null;
       } catch (error) {
+        if (error instanceof StreamAbortError) {
+          // User aborted - clear partial response
+          setChatMessages((prev) => {
+            const updated = [...prev];
+            if (
+              updated.length > 0 &&
+              updated[updated.length - 1].role === "assistant"
+            ) {
+              updated.pop();
+            }
+            return updated;
+          });
+          setIsLoading(false);
+          setIsResponseActive(false);
+          abortControllerRef.current = null;
+          return;
+        }
         console.error("Failed to get chat response:", error);
         setIsLoading(false);
+        setIsResponseActive(false);
+        abortControllerRef.current = null;
         setChatMessages((prev) => [
           ...prev,
           {
@@ -249,6 +284,13 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
     [handler, currentIssue, context],
   );
 
+  const handleInterrupt = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+  }, []);
+
   return (
     <Box flexDirection="column">
       <ExplainComponent issue={currentIssue} />
@@ -266,6 +308,8 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
           prNumber={prNumber}
           enableMentions={currentIssue.type === "discussion"}
           onBack={onBack}
+          onInterrupt={handleInterrupt}
+          isResponseActive={isResponseActive}
         />
       </Box>
     </Box>

--- a/src/pages/IssueBrowser.tsx
+++ b/src/pages/IssueBrowser.tsx
@@ -123,7 +123,6 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
     async (message: string) => {
       setChatMessages((prev) => [...prev, { role: "user", content: message }]);
       setIsLoading(true);
-
       const abortController = new AbortController();
       abortControllerRef.current = abortController;
       setIsResponseActive(true);
@@ -134,6 +133,7 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
           currentIssue,
           conversationId,
         );
+
         await processStream(
           request,
           {
@@ -164,8 +164,6 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
           },
           abortController.signal,
         );
-        setIsResponseActive(false);
-        abortControllerRef.current = null;
       } catch (error) {
         if (error instanceof StreamAbortError) {
           // User aborted - clear partial response
@@ -179,15 +177,9 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
             }
             return updated;
           });
-          setIsLoading(false);
-          setIsResponseActive(false);
-          abortControllerRef.current = null;
           return;
         }
         console.error("Failed to get chat response:", error);
-        setIsLoading(false);
-        setIsResponseActive(false);
-        abortControllerRef.current = null;
         setChatMessages((prev) => [
           ...prev,
           {
@@ -195,6 +187,9 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
             content: "Sorry, I encountered an error. Please try again.",
           },
         ]);
+      } finally {
+        setIsResponseActive(false);
+        abortControllerRef.current = null;
       }
     },
     [buildChatRequest, currentIssue, conversationId],

--- a/src/pages/SpecReview/SpecReviewBrowser.tsx
+++ b/src/pages/SpecReview/SpecReviewBrowser.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useCallback } from "react";
 import { Box, Text } from "ink";
 import type { Requirement } from "../../lib/providers/index.js";
 import { MAIN_COLOR } from "../../theme/colors.js";
@@ -6,7 +6,7 @@ import { renderMarkdown } from "../../lib/markdown.js";
 import ChatDisplay from "../chat/ChatDisplay.js";
 import { ChatMessage, IssueType } from "../../models/chat.js";
 import { IssueCommand } from "../../issues/types.js";
-import { processStream } from "../../lib/chat-stream.js";
+import { processStream, StreamAbortError } from "../../lib/chat-stream.js";
 
 interface SpecReviewBrowserProps {
   unmetRequirements: Requirement[];
@@ -32,6 +32,8 @@ const SpecReviewBrowser: React.FC<SpecReviewBrowserProps> = ({
   );
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [isResponseActive, setIsResponseActive] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const currentRequirement = unmetRequirements[currentIndex];
 
@@ -40,80 +42,113 @@ const SpecReviewBrowser: React.FC<SpecReviewBrowserProps> = ({
     return null;
   }
 
-  const handleChatSubmit = async (message: string) => {
-    const userMessage: ChatMessage = {
-      role: "user",
-      content: message,
-    };
+  const handleChatSubmit = useCallback(
+    async (message: string) => {
+      const userMessage: ChatMessage = {
+        role: "user",
+        content: message,
+      };
 
-    setChatMessages((prev) => [...prev, userMessage]);
-    setIsLoading(true);
+      setChatMessages((prev) => [...prev, userMessage]);
+      setIsLoading(true);
 
-    const assistantMessage: ChatMessage = {
-      role: "assistant",
-      content: "",
-    };
+      const assistantMessage: ChatMessage = {
+        role: "assistant",
+        content: "",
+      };
 
-    setChatMessages((prev) => [...prev, assistantMessage]);
+      setChatMessages((prev) => [...prev, assistantMessage]);
 
-    if (!bazRepoId) {
-      console.error("Repository ID not available for chat");
-      setIsLoading(false);
-      setChatMessages((prev) => {
-        const updated = [...prev];
-        updated[updated.length - 1] = {
-          role: "assistant",
-          content: "Repository ID not available. Please try again.",
-        };
-        return updated;
-      });
-      return;
-    }
+      if (!bazRepoId) {
+        console.error("Repository ID not available for chat");
+        setIsLoading(false);
+        setChatMessages((prev) => {
+          const updated = [...prev];
+          updated[updated.length - 1] = {
+            role: "assistant",
+            content: "Repository ID not available. Please try again.",
+          };
+          return updated;
+        });
+        return;
+      }
 
-    try {
-      await processStream(
-        {
-          mode: "baz",
-          repoId: bazRepoId,
-          prId,
-          issue: {
-            type: IssueType.SPEC_REVIEW,
-            data: {
-              id: currentRequirement.id,
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+      setIsResponseActive(true);
+
+      try {
+        await processStream(
+          {
+            mode: "baz",
+            repoId: bazRepoId,
+            prId,
+            issue: {
+              type: IssueType.SPEC_REVIEW,
+              data: {
+                id: currentRequirement.id,
+              },
+            },
+            freeText: message,
+            conversationId,
+          },
+          {
+            onConversationId: (id) => setConversationId(id),
+            onFirstTextContent: () => setIsLoading(false),
+            onUpdate: (content, toolCalls) => {
+              setChatMessages((prev) => {
+                const updated = [...prev];
+                updated[updated.length - 1] = {
+                  role: "assistant",
+                  content,
+                  toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+                };
+                return updated;
+              });
+            },
+            onAbort: () => {
+              setIsLoading(false);
+              setIsResponseActive(false);
             },
           },
-          freeText: message,
-          conversationId,
-        },
-        {
-          onConversationId: (id) => setConversationId(id),
-          onFirstTextContent: () => setIsLoading(false),
-          onUpdate: (content, toolCalls) => {
-            setChatMessages((prev) => {
-              const updated = [...prev];
-              updated[updated.length - 1] = {
-                role: "assistant",
-                content,
-                toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-              };
-              return updated;
-            });
-          },
-        },
-      );
-    } catch (error) {
-      console.error("Failed to get chat response:", error);
-      setIsLoading(false);
-      setChatMessages((prev) => {
-        const updated = [...prev];
-        updated[updated.length - 1] = {
-          role: "assistant",
-          content: "Sorry, I encountered an error. Please try again.",
-        };
-        return updated;
-      });
-    }
-  };
+          abortController.signal,
+        );
+        setIsResponseActive(false);
+        abortControllerRef.current = null;
+      } catch (error) {
+        if (error instanceof StreamAbortError) {
+          // User aborted - clear partial response
+          setChatMessages((prev) => {
+            const updated = [...prev];
+            if (
+              updated.length > 0 &&
+              updated[updated.length - 1].role === "assistant"
+            ) {
+              updated.pop();
+            }
+            return updated;
+          });
+          setIsLoading(false);
+          setIsResponseActive(false);
+          abortControllerRef.current = null;
+          return;
+        }
+        console.error("Failed to get chat response:", error);
+        setIsLoading(false);
+        setIsResponseActive(false);
+        abortControllerRef.current = null;
+        setChatMessages((prev) => {
+          const updated = [...prev];
+          updated[updated.length - 1] = {
+            role: "assistant",
+            content: "Sorry, I encountered an error. Please try again.",
+          };
+          return updated;
+        });
+      }
+    },
+    [bazRepoId, prId, currentRequirement.id, conversationId],
+  );
 
   const handleNext = () => {
     setCurrentIndex((prev) => {
@@ -136,23 +171,33 @@ const SpecReviewBrowser: React.FC<SpecReviewBrowserProps> = ({
     setViewState("evidence");
   };
 
-  const handleSubmit = async (message: string) => {
-    if (message.startsWith("/")) {
-      const spaceIndex = message.indexOf(" ");
-      const command =
-        spaceIndex === -1 ? message.slice(1) : message.slice(1, spaceIndex);
+  const handleSubmit = useCallback(
+    async (message: string) => {
+      if (message.startsWith("/")) {
+        const spaceIndex = message.indexOf(" ");
+        const command =
+          spaceIndex === -1 ? message.slice(1) : message.slice(1, spaceIndex);
 
-      if (command === "next") {
-        handleNext();
-        return;
-      } else if (command === "explain") {
-        handleExplain();
-        return;
+        if (command === "next") {
+          handleNext();
+          return;
+        } else if (command === "explain") {
+          handleExplain();
+          return;
+        }
       }
-    }
 
-    await handleChatSubmit(message);
-  };
+      await handleChatSubmit(message);
+    },
+    [handleChatSubmit, handleNext, handleExplain],
+  );
+
+  const handleInterrupt = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+  }, []);
 
   const availableCommands: IssueCommand[] = [
     {
@@ -213,6 +258,8 @@ const SpecReviewBrowser: React.FC<SpecReviewBrowserProps> = ({
           enableMentions={false}
           onBack={onBack}
           placeholder="Ask about this requirement..."
+          onInterrupt={handleInterrupt}
+          isResponseActive={isResponseActive}
         />
       </Box>
     </Box>

--- a/src/pages/chat/ChatDisplay.tsx
+++ b/src/pages/chat/ChatDisplay.tsx
@@ -171,7 +171,7 @@ const ChatDisplay = memo<ChatDisplayProps>(
     );
 
     useInput(
-      (input, key) => {
+      (_input, key) => {
         if (key.escape && isResponseActive && onInterrupt) {
           onInterrupt();
         } else if (key.tab && activeToolCalls.length > 0) {

--- a/src/pages/chat/ChatDisplay.tsx
+++ b/src/pages/chat/ChatDisplay.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { Box, Text, useStdout } from "ink";
+import { Box, Text, useStdout, useInput } from "ink";
 import Spinner from "ink-spinner";
 import { ChatMessage } from "../../models/chat.js";
 import { IssueCommand } from "../../issues/types.js";
@@ -112,6 +112,8 @@ interface ChatDisplayProps {
   prNumber?: number;
   enableMentions?: boolean;
   onBack: () => void;
+  onInterrupt?: () => void;
+  isResponseActive?: boolean;
 }
 
 const ChatDisplay = memo<ChatDisplayProps>(
@@ -127,6 +129,8 @@ const ChatDisplay = memo<ChatDisplayProps>(
     prNumber,
     enableMentions = false,
     onBack,
+    onInterrupt,
+    isResponseActive = false,
   }) => {
     const { stdout } = useStdout();
     const [terminalWidth, setTerminalWidth] = useState(stdout?.columns ?? 80);
@@ -166,6 +170,17 @@ const ChatDisplay = memo<ChatDisplayProps>(
       [onSubmit],
     );
 
+    useInput(
+      (input, key) => {
+        if (key.escape && isResponseActive && onInterrupt) {
+          onInterrupt();
+        } else if (key.tab && activeToolCalls.length > 0) {
+          toggleTools();
+        }
+      },
+      { isActive: isLoading || hasPendingToolCalls },
+    );
+
     return (
       <Box flexDirection="column">
         <Box flexDirection="column">
@@ -180,10 +195,17 @@ const ChatDisplay = memo<ChatDisplayProps>(
         </Box>
 
         {(isLoading || hasPendingToolCalls) && (
-          <Box marginBottom={1}>
-            <Text color="magenta">
-              <Spinner type="dots" /> Thinking...
-            </Text>
+          <Box flexDirection="column" marginBottom={1}>
+            <Box>
+              <Text color="magenta">
+                <Spinner type="dots" /> Thinking...
+              </Text>
+            </Box>
+            {isResponseActive && (
+              <Box marginTop={1}>
+                <Text dimColor>Press ESC to stop response</Text>
+              </Box>
+            )}
           </Box>
         )}
 
@@ -200,6 +222,8 @@ const ChatDisplay = memo<ChatDisplayProps>(
             terminalWidth={terminalWidth}
             toolsExist={activeToolCalls.length > 0}
             onToggleToolCallExpansion={toggleTools}
+            onInterrupt={onInterrupt}
+            isResponseActive={isResponseActive}
           />
         )}
       </Box>

--- a/src/pages/chat/ChatInput.tsx
+++ b/src/pages/chat/ChatInput.tsx
@@ -25,6 +25,8 @@ interface ChatInputProps {
   toolsExist: boolean;
   onToggleToolCallExpansion: () => void;
   terminalWidth: number;
+  onInterrupt?: () => void;
+  isResponseActive?: boolean;
 }
 
 // Throttle updates ~60fps
@@ -43,6 +45,8 @@ const ChatInput = memo<ChatInputProps>((props) => {
     toolsExist,
     onToggleToolCallExpansion,
     terminalWidth,
+    onInterrupt,
+    isResponseActive = false,
   } = props;
 
   const appMode = useAppMode();
@@ -216,7 +220,11 @@ const ChatInput = memo<ChatInputProps>((props) => {
         cursorRef.current = mention.startIndex;
         setMention({ show: false, query: "", startIndex: -1 });
         syncDisplay(true);
-      } else onBack();
+      } else if (isResponseActive && onInterrupt) {
+        onInterrupt();
+      } else {
+        onBack();
+      }
       return;
     }
 


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
SpecReviewBrowser_handleChatSubmit_("SpecReviewBrowser.handleChatSubmit"):::added
processStream_("processStream"):::modified
SpecReviewBrowser_handleInterrupt_("SpecReviewBrowser.handleInterrupt"):::added
StreamAbortError_("StreamAbortError"):::added
SpecReviewBrowser_("SpecReviewBrowser"):::modified
ChatDisplay_("ChatDisplay"):::added
PRChat_runChatStream_("PRChat.runChatStream"):::added
PRChat_handleInterrupt_("PRChat.handleInterrupt"):::added
PRChat_("PRChat"):::modified
IssueBrowser_handleInterrupt_("IssueBrowser.handleInterrupt"):::added
IssueBrowser_("IssueBrowser"):::modified
SpecReviewBrowser_handleChatSubmit_ -- "Adds streaming chat with abort support in submission" --> processStream_
SpecReviewBrowser_handleInterrupt_ -- "Handles user interrupt by aborting chat stream" --> StreamAbortError_
SpecReviewBrowser_ -- "Integrates ChatDisplay with interrupt and response state props" --> ChatDisplay_
PRChat_runChatStream_ -- "Processes chat stream with abort and update callbacks" --> processStream_
PRChat_handleInterrupt_ -- "Aborts chat stream on user interrupt event" --> StreamAbortError_
PRChat_ -- "Displays chat with interrupt and active response support" --> ChatDisplay_
IssueBrowser_handleInterrupt_ -- "Handles user aborts by throwing StreamAbortError" --> StreamAbortError_
IssueBrowser_ -- "Renders chat with interrupt and response active state support" --> ChatDisplay_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enable users to interrupt ongoing agent responses by pressing the <code>ESC</code> key, preventing wasted time and improving iteration. Integrate stream abortion logic across core streaming utilities and various chat UI components, allowing for immediate cessation of agent reasoning and response generation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/90?tool=ast&topic=UI+Integration+%26+UX>UI Integration & UX</a>
        </td><td>Integrate the stream abortion mechanism into the user interface, allowing users to press <code>ESC</code> to stop an active agent response. This involves adding <code>onInterrupt</code> callbacks and <code>isResponseActive</code> state to chat components, updating the UI to display interruption instructions, and handling <code>StreamAbortError</code> to clear partial responses.<details><summary>Modified files (6)</summary><ul><li>src/pages/SpecReview/MetRequirementBrowser.tsx</li>
<li>src/pages/SpecReview/SpecReviewBrowser.tsx</li>
<li>src/pages/chat/ChatDisplay.tsx</li>
<li>src/pages/PRChat/PRChat.tsx</li>
<li>src/pages/chat/ChatInput.tsx</li>
<li>src/pages/IssueBrowser.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>fix-fix-discussion-tok...</td><td>December 16, 2025</td></tr>
<tr><td>anton.gruebel@gmail.com</td><td>feat-add-option-to-Cha...</td><td>December 14, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/90?tool=ast&topic=Stream+Abortion+Logic>Stream Abortion Logic</a>
        </td><td>Implement the core functionality for aborting chat streams, including defining an <code>AbortSignal</code> interface, handling cancellation errors from the network client, and propagating a custom <code>StreamAbortError</code> to ensure consistent error handling throughout the application.<details><summary>Modified files (2)</summary><ul><li>src/lib/chat-stream.ts</li>
<li>src/lib/clients/baz.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrod@baz.co</td><td>feat-support-paginatio...</td><td>December 16, 2025</td></tr>
<tr><td>yuvalyacoby</td><td>fix-fix-merge-actions-77</td><td>December 15, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/90?tool=ast>(Baz)</a>.