### PR TITLE
feat: Ready to merge

### DIFF
--- a/src/lib/clients/baz.ts
+++ b/src/lib/clients/baz.ts
@@ -193,6 +193,8 @@ function mapBazRunStatus(status: string): PRRunStatus {
     "pending",
     "unknown",
     "expected",
+    "in_progress",
+    "queued",
   ];
 
   if (validStatuses.includes(normalized as PRRunStatus)) {

--- a/src/lib/clients/baz.ts
+++ b/src/lib/clients/baz.ts
@@ -142,7 +142,7 @@ export interface BazPullRequest {
   repositoryName: string;
   authorName: string;
   updatedAt: string;
-  mergeable: boolean | null;
+  isMergeable: boolean | null;
   runs: PRRunResponse[];
   reviews: CodeChangeReviewResponse[];
 }
@@ -234,7 +234,7 @@ export async function fetchPRs(): Promise<PullRequest[]> {
         repositoryName: change.repositoryName,
         authorName: change.authorName,
         updatedAt: change.updatedAt,
-        mergeable: change.mergeable,
+        mergeable: change.isMergeable,
         runs: mapBazRunsToPRRuns(change.runs ?? []),
         reviews: mapBazReviewsToCodeChangeReviews(change.reviews),
       })),
@@ -405,7 +405,10 @@ export async function fetchMergeStatus(prId: string): Promise<MergeStatus> {
         "Content-Type": "application/json",
       },
     })
-    .then((value) => value.data)
+    .then((value) => ({
+      is_mergeable: value.data.is_mergeable,
+      merge_strategy: value.data.default_merge_strategy,
+    }))
     .catch((error: unknown) => {
       logger.debug(`Axios error while fetching merge status: ${error}`);
       throw error;

--- a/src/lib/clients/github.ts
+++ b/src/lib/clients/github.ts
@@ -159,7 +159,6 @@ function mapGitHubStatusToRuns(
   return [
     {
       name: "CI Status",
-      isRequired: true,
       status,
     },
   ];

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -14,43 +14,18 @@ export interface PullRequest {
 
 export interface PRRun {
   name: string;
-  isRequired: boolean;
   status: PRRunStatus;
 }
 
-export type PRRunStatus = "success" | "failure" | "in_progress" | "queued" | "pending" | "cancelled" | "unknown" | "expected";
-
-export interface PullRequestResponse {
-  id: string;
-  pr_number: number;
-  title: string;
-  description: string;
-  repo_id: string;
-  repo_full_name: string;
-  author_name: string;
-  updated_at: string;
-  is_mergeable: boolean;
-  runs?: PRRunResponse[];
-  reviews: CodeChangeReviewResponse[];
-}
-
-export interface PRRunResponse {
-  ci_name: string;
-  name: string;
-  status: string;
-  link?: string;
-  required: boolean;
-  started_at?: string;
-  completed_at?: string;
-}
-
-export interface CodeChangeReviewResponse {
-  state: string;
-  created_at: string;
-  updated_at: string;
-  reviewer: string;
-  has_write_access: boolean;
-}
+export type PRRunStatus =
+  | "success"
+  | "failure"
+  | "in_progress"
+  | "queued"
+  | "pending"
+  | "cancelled"
+  | "unknown"
+  | "expected";
 
 export interface PullRequestDetails {
   id: string;

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -7,6 +7,49 @@ export interface PullRequest {
   repositoryName: string;
   authorName: string;
   updatedAt: string;
+  mergeable: boolean | null;
+  runs: PRRun[];
+  reviews: CodeChangeReview[];
+}
+
+export interface PRRun {
+  name: string;
+  isRequired: boolean;
+  status: PRRunStatus;
+}
+
+export type PRRunStatus = "success" | "failure" | "in_progress" | "queued" | "pending" | "cancelled" | "unknown" | "expected";
+
+export interface PullRequestResponse {
+  id: string;
+  pr_number: number;
+  title: string;
+  description: string;
+  repo_id: string;
+  repo_full_name: string;
+  author_name: string;
+  updated_at: string;
+  is_mergeable: boolean;
+  runs?: PRRunResponse[];
+  reviews: CodeChangeReviewResponse[];
+}
+
+export interface PRRunResponse {
+  ci_name: string;
+  name: string;
+  status: string;
+  link?: string;
+  required: boolean;
+  started_at?: string;
+  completed_at?: string;
+}
+
+export interface CodeChangeReviewResponse {
+  state: string;
+  created_at: string;
+  updated_at: string;
+  reviewer: string;
+  has_write_access: boolean;
 }
 
 export interface PullRequestDetails {

--- a/src/pages/PRSelector/MergeConfirmationPrompt.tsx
+++ b/src/pages/PRSelector/MergeConfirmationPrompt.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import Spinner from "ink-spinner";
+import type { PullRequest, PRContext } from "../../lib/providers/index.js";
+import { useAppMode } from "../../lib/config/AppModeContext.js";
+import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+import { MAIN_COLOR } from "../../theme/colors.js";
+
+interface MergeConfirmationPromptProps {
+  pr: PullRequest;
+  updateData: (updater: (prev: PullRequest[]) => PullRequest[]) => void;
+  onComplete: () => void;
+  onCancel: () => void;
+}
+
+type MergeState = "confirming" | "merging" | "error";
+
+interface MergeConfirmItem {
+  label: string;
+  value: "yes" | "goBack";
+}
+
+const MergeConfirmationPrompt: React.FC<MergeConfirmationPromptProps> = ({
+  pr,
+  updateData,
+  onComplete,
+  onCancel,
+}) => {
+  const [state, setState] = useState<MergeState>("confirming");
+  const [error, setError] = useState<string>("");
+  const appMode = useAppMode();
+
+  const handleConfirm = async (item: MergeConfirmItem) => {
+    if (item.value === "goBack") {
+      onCancel();
+      return;
+    }
+
+    setState("merging");
+
+    try {
+      const prContext: PRContext = {
+        prId: pr.id,
+        fullRepoName: pr.repositoryName,
+        prNumber: pr.prNumber,
+      };
+
+      const mergeStatus =
+        await appMode.mode.dataProvider.fetchMergeStatus(prContext);
+
+      await appMode.mode.dataProvider.mergePR(
+        prContext,
+        mergeStatus.merge_strategy,
+      );
+
+      updateData((prevPRs) => prevPRs.filter((p) => p.id !== pr.id));
+
+      onComplete();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setState("error");
+    }
+  };
+
+  useInput((_input, key) => {
+    if (state === "error" && key.escape) {
+      onCancel();
+    }
+  });
+
+  if (state === "confirming") {
+    const items: MergeConfirmItem[] = [
+      { label: "Yes", value: "yes" },
+      { label: "Go back", value: "goBack" },
+    ];
+
+    return (
+      <Box flexDirection="column">
+        <Box marginBottom={1}>
+          <Text bold color="yellow">
+            Merge {pr.title}?
+          </Text>
+        </Box>
+        <SelectInput
+          items={items}
+          onSelect={handleConfirm}
+          indicatorComponent={({ isSelected }) => (
+            <Text color={isSelected ? "green" : "gray"}>
+              {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
+            </Text>
+          )}
+          itemComponent={({ isSelected, label }) => (
+            <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+          )}
+        />
+        <Box marginTop={1}>
+          <Text dimColor italic>
+            Use ↑↓ arrows and Enter to select
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (state === "merging") {
+    return (
+      <Box>
+        <Text color={MAIN_COLOR}>
+          <Spinner type="dots" />
+        </Text>
+        <Text color={MAIN_COLOR}> Merging PR...</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text color="red" bold>
+          ✗ Failed to merge PR: {error}
+        </Text>
+      </Box>
+      <Box>
+        <Text dimColor italic>
+          Press ESC to return to selector
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export default MergeConfirmationPrompt;

--- a/src/pages/PRSelector/PullRequestCard.tsx
+++ b/src/pages/PRSelector/PullRequestCard.tsx
@@ -11,6 +11,7 @@ import { MAIN_COLOR } from "../../theme/colors.js";
 interface PullRequestCardProps {
   pr: PullRequest;
   isSelected: boolean;
+  canMerge: boolean;
   currentUserLogin?: string;
 }
 
@@ -103,6 +104,7 @@ export const PullRequestCard: React.FC<PullRequestCardProps> = ({
   pr,
   isSelected,
   currentUserLogin,
+  canMerge,
 }) => {
   const ciStatus = getCIStatus(pr.runs);
   const ciIcon = getCIIcon(ciStatus);
@@ -134,8 +136,13 @@ export const PullRequestCard: React.FC<PullRequestCardProps> = ({
         <Text dimColor={!isSelected} color={reviewDisplay.color}>
           {reviewDisplay.text}
         </Text>
-        {ciIcon?.text && <Text>" • " CI {ciIcon.text}</Text>}
+        {ciIcon?.text && <Text> • CI {ciIcon.text}</Text>}
       </Text>
+      {canMerge && (
+        <Text bold color="green">
+          {"    "}Want to merge? Ctrl+G and let's go!
+        </Text>
+      )}
     </Box>
   );
 };

--- a/src/pages/PRSelector/PullRequestCard.tsx
+++ b/src/pages/PRSelector/PullRequestCard.tsx
@@ -88,7 +88,7 @@ function getReviewStatusDisplay(status: ReviewStatus): {
 } {
   switch (status) {
     case "waiting_review":
-      return { text: "● Waiting review", color: "black" };
+      return { text: "● Awaiting review", color: "black" };
     case "reviewed":
       return { text: "◐ Reviewed", color: "yellow" };
     case "reviewed_by_me":
@@ -110,7 +110,7 @@ export const PullRequestCard: React.FC<PullRequestCardProps> = ({
   const ciIcon = getCIIcon(ciStatus);
   const reviewStatus = getReviewStatus(pr.reviews, currentUserLogin);
   const reviewDisplay = getReviewStatusDisplay(reviewStatus);
-  const timeShort = pr.updatedAt;
+  const updatedTime = pr.updatedAt;
 
   const titleColor = isSelected ? "cyan" : "white";
   const metadataColor = isSelected ? MAIN_COLOR : "white";
@@ -131,7 +131,7 @@ export const PullRequestCard: React.FC<PullRequestCardProps> = ({
       <Text dimColor={!isSelected} color={metadataColor}>
         {"    "}by {pr.authorName}
         {" • "}
-        {timeShort}
+        {updatedTime}
         {" • "}
         <Text dimColor={!isSelected} color={reviewDisplay.color}>
           {reviewDisplay.text}

--- a/src/pages/PRSelector/PullRequestCard.tsx
+++ b/src/pages/PRSelector/PullRequestCard.tsx
@@ -134,8 +134,7 @@ export const PullRequestCard: React.FC<PullRequestCardProps> = ({
         <Text dimColor={!isSelected} color={reviewDisplay.color}>
           {reviewDisplay.text}
         </Text>
-        {" • "}
-        {ciIcon?.text && <Text>CI {ciIcon.text}</Text>}
+        {ciIcon?.text && <Text>" • " CI {ciIcon.text}</Text>}
       </Text>
     </Box>
   );

--- a/src/pages/PRSelector/PullRequestCard.tsx
+++ b/src/pages/PRSelector/PullRequestCard.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { Box, Text } from "ink";
+import type {
+  PullRequest,
+  PRRun,
+  CodeChangeReview,
+} from "../../lib/providers/index.js";
+import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+import { MAIN_COLOR } from "../../theme/colors.js";
+
+interface PullRequestCardProps {
+  pr: PullRequest;
+  isSelected: boolean;
+  currentUserLogin?: string;
+}
+
+type CIStatus = "success" | "pending" | "failure" | "none";
+
+type ReviewStatus =
+  | "waiting_review"
+  | "reviewed"
+  | "reviewed_by_me"
+  | "approved"
+  | "approved_by_me";
+
+function getCIStatus(runs: PRRun[]): CIStatus {
+  if (!runs || runs.length === 0) return "none";
+  const hasFailure = runs.some((run) => run.status === "failure");
+  if (hasFailure) return "failure";
+  const hasPending = runs.some(
+    (run) =>
+      run.status === "pending" ||
+      run.status === "in_progress" ||
+      run.status === "queued",
+  );
+  if (hasPending) return "pending";
+  const allSuccess = runs.every((run) => run.status === "success");
+  if (allSuccess) return "success";
+  return "none";
+}
+
+function getCIIcon(status: CIStatus): { icon: string; color: string } {
+  switch (status) {
+    case "success":
+      return { icon: "✓", color: "green" };
+    case "pending":
+      return { icon: "●", color: "yellow" };
+    case "failure":
+      return { icon: "✗", color: "red" };
+    case "none":
+      return { icon: "", color: "gray" };
+  }
+}
+
+function getReviewStatus(
+  reviews: CodeChangeReview[],
+  currentUserLogin?: string,
+): ReviewStatus {
+  if (!reviews || reviews.length === 0) {
+    return "waiting_review";
+  }
+  const hasApprovals = reviews.some((r) => r.review_state === "approved");
+  const userReview = reviews.find(
+    (r) => currentUserLogin && r.assignee === currentUserLogin,
+  );
+  if (userReview) {
+    if (userReview.review_state === "approved") {
+      return "approved_by_me";
+    }
+    return "reviewed_by_me";
+  }
+  if (hasApprovals) {
+    return "approved";
+  }
+  return "reviewed";
+}
+
+function getReviewStatusText(status: ReviewStatus): string {
+  switch (status) {
+    case "waiting_review":
+      return "⏳ Waiting review";
+    case "reviewed":
+      return "📝 Reviewed";
+    case "reviewed_by_me":
+      return "📝 Reviewed by me";
+    case "approved":
+      return "✅ Approved";
+    case "approved_by_me":
+      return "✅ Approved by me";
+  }
+}
+
+function getReviewStatusColor(status: ReviewStatus): string {
+  switch (status) {
+    case "waiting_review":
+      return "gray";
+    case "reviewed":
+    case "reviewed_by_me":
+      return "yellow";
+    case "approved":
+    case "approved_by_me":
+      return "green";
+  }
+}
+
+function formatTimeShort(timeStr: string): string {
+  // Convert time strings to short format
+  return timeStr
+    .replace(/(\d+)\s*days?\s*ago/, "$1d")
+    .replace(/(\d+)\s*hours?\s*ago/, "$1h")
+    .replace(/(\d+)\s*minutes?\s*ago/, "$1m")
+    .replace(/(\d+)\s*seconds?\s*ago/, "$1s")
+    .replace("just now", "now")
+    .replace("updated ", "");
+}
+
+export const PullRequestCard: React.FC<PullRequestCardProps> = ({
+  pr,
+  isSelected,
+  currentUserLogin,
+}) => {
+  const ciStatus = getCIStatus(pr.runs);
+  const ciIcon = getCIIcon(ciStatus);
+  const reviewStatus = getReviewStatus(pr.reviews, currentUserLogin);
+  const reviewText = getReviewStatusText(reviewStatus);
+  const reviewColor = getReviewStatusColor(reviewStatus);
+  const timeShort = formatTimeShort(pr.updatedAt);
+
+  const titleColor = isSelected ? "cyan" : "white";
+  const metadataColor = isSelected ? MAIN_COLOR : "white";
+
+  return (
+    <Box flexDirection="column">
+      <Box justifyContent="space-between">
+        <Text color={titleColor}>
+          {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}#{pr.prNumber}{" "}
+          {pr.title}
+        </Text>
+        {ciIcon.icon && <Text color={ciIcon.color}>{ciIcon.icon}</Text>}
+      </Box>
+      <Text color={metadataColor}>
+        {"         "}
+        <Text color="gray">{pr.repositoryName}</Text>
+        {" • "}
+        {pr.authorName}
+        {" • "}
+        {timeShort}
+        {" • "}
+        <Text color={reviewColor}>{reviewText}</Text>
+      </Text>
+    </Box>
+  );
+};

--- a/src/pages/PRSelector/PullRequestSelector.tsx
+++ b/src/pages/PRSelector/PullRequestSelector.tsx
@@ -97,7 +97,7 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
       setSelectedIndex((prev) => Math.max(0, prev - 1));
     } else if (key.downArrow) {
       setSelectedIndex((prev) => Math.min(filteredPRs.length - 1, prev + 1));
-    } else if (key.return && !key.ctrl) {
+    } else if (key.return) {
       handleSubmit();
     } else if (key.ctrl && input === "g") {
       if (canMergeSelectedPr && selectedPr) {

--- a/src/pages/PRSelector/PullRequestSelector.tsx
+++ b/src/pages/PRSelector/PullRequestSelector.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState, useRef } from "react";
 import { Box, Text, useInput } from "ink";
 import type { PullRequest } from "../../lib/providers/index.js";
-import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
-import { MAIN_COLOR } from "../../theme/colors.js";
 import { updatedTimeAgo } from "../../lib/date.js";
+import { PullRequestCard } from "./PullRequestCard.js";
+import { useFetchUser } from "../../hooks/useFetchUser.js";
 
 interface PullRequestSearchKeywords {
   author?: string;
@@ -26,6 +26,7 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const isFirstRender = useRef(true);
+  const { data: user } = useFetchUser();
 
   const initialIndex = initialPrId
     ? pullRequests.findIndex((pr) => pr.id === initialPrId)
@@ -116,9 +117,7 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
           <Text color="gray">Search: </Text>
           <Text>
             {searchQuery || (
-              <Text dimColor>
-                Try: repo:myrepo, author:username bug fix...
-              </Text>
+              <Text dimColor>Try: repo:myrepo, author:username bug fix...</Text>
             )}
           </Text>
         </Box>
@@ -163,28 +162,12 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
                     {visiblePRs.map((pr, index) => {
                       const actualIndex = startIndex + index;
                       return (
-                        <Box key={pr.id} flexDirection="column">
-                          <Text
-                            color={
-                              actualIndex === selectedIndex ? "cyan" : "white"
-                            }
-                          >
-                            {actualIndex === selectedIndex
-                              ? ITEM_SELECTOR
-                              : ITEM_SELECTION_GAP}
-                            #{pr.prNumber} {pr.title}
-                            <Text color="gray"> [{pr.repositoryName}]</Text>
-                          </Text>
-                          <Text
-                            color={
-                              actualIndex === selectedIndex
-                                ? MAIN_COLOR
-                                : "white"
-                            }
-                          >
-                            {`${ITEM_SELECTION_GAP}  by ${pr.authorName} ⏺ ${pr.updatedAt}`}
-                          </Text>
-                        </Box>
+                        <PullRequestCard
+                          key={pr.id}
+                          pr={pr}
+                          isSelected={actualIndex === selectedIndex}
+                          currentUserLogin={user?.login}
+                        />
                       );
                     })}
                     {endIndex < filteredPRs.length && (

--- a/src/pages/PRSelector/PullRequestSelector.tsx
+++ b/src/pages/PRSelector/PullRequestSelector.tsx
@@ -111,9 +111,24 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
         </Text>
       </Box>
 
-      <Box marginBottom={1}>
-        <Text color="gray">Search: </Text>
-        <Text>{searchQuery || <Text dimColor>Type to search...</Text>}</Text>
+      <Box flexDirection="column" marginBottom={1}>
+        <Box>
+          <Text color="gray">Search: </Text>
+          <Text>
+            {searchQuery || (
+              <Text dimColor>
+                Try: repo:myrepo, author:username bug fix...
+              </Text>
+            )}
+          </Text>
+        </Box>
+        {!searchQuery && (
+          <Box marginTop={0}>
+            <Text dimColor italic>
+              💡 Use repo:name, author:user to filter
+            </Text>
+          </Box>
+        )}
       </Box>
 
       <Box flexDirection="column" marginTop={1}>

--- a/src/pages/PRSelector/PullRequestSelector.tsx
+++ b/src/pages/PRSelector/PullRequestSelector.tsx
@@ -119,11 +119,10 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
 
   const selectedPr = filteredPRs[selectedIndex];
   const canMergeSelectedPr =
-    selectedPr &&
-    selectedPr.mergeable === true &&
-    (selectedPr.runs.length === 0 ||
-      selectedPr.runs.every((run) => run.status === "success")) &&
-    selectedPr.reviews.some((review) => review.review_state === "approved");
+    selectedPr?.mergeable === true &&
+    (selectedPr?.runs.length === 0 ||
+      selectedPr?.runs.every((run) => run.status === "success")) &&
+    selectedPr?.reviews.some((review) => review.review_state === "approved");
 
   if (showMergePrompt && prToMerge) {
     return (
@@ -132,7 +131,7 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
         updateData={updateData}
         onComplete={() => {
           setSearchQuery("");
-          setSelectedIndex((prev) => Math.min(prev, pullRequests.length - 2));
+          setSelectedIndex(0);
           setShowMergePrompt(false);
           setPrToMerge(null);
         }}

--- a/src/pages/PRSelector/PullRequestSelector.tsx
+++ b/src/pages/PRSelector/PullRequestSelector.tsx
@@ -117,12 +117,17 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
     }
   };
 
+  const canMergePR = (pr: PullRequest) => {
+    return (
+      pr.mergeable === true &&
+      (pr.runs.length === 0 ||
+        pr.runs.every((run) => run.status === "success")) &&
+      pr.reviews.some((review) => review.review_state === "approved")
+    );
+  };
+
   const selectedPr = filteredPRs[selectedIndex];
-  const canMergeSelectedPr =
-    selectedPr?.mergeable === true &&
-    (selectedPr?.runs.length === 0 ||
-      selectedPr?.runs.every((run) => run.status === "success")) &&
-    selectedPr?.reviews.some((review) => review.review_state === "approved");
+  const canMergeSelectedPr = selectedPr ? canMergePR(selectedPr) : false;
 
   if (showMergePrompt && prToMerge) {
     return (
@@ -200,12 +205,14 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
                     )}
                     {visiblePRs.map((pr, index) => {
                       const actualIndex = startIndex + index;
+                      const isSelected = actualIndex === selectedIndex;
                       return (
                         <PullRequestCard
                           key={pr.id}
                           pr={pr}
-                          isSelected={actualIndex === selectedIndex}
+                          isSelected={isSelected}
                           currentUserLogin={user?.login}
+                          canMerge={isSelected && canMergePR(pr)}
                         />
                       );
                     })}
@@ -226,16 +233,6 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
         <Text dimColor italic>
           Type to search • ↑↓ to navigate • Enter to select • Ctrl+C to cancel
         </Text>
-        {canMergeSelectedPr && (
-          <>
-            <Text dimColor italic>
-              {" • "}
-            </Text>
-            <Text bold color="cyan">
-              Ctrl+G to merge
-            </Text>
-          </>
-        )}
       </Box>
     </Box>
   );

--- a/src/pages/PRSelector/PullRequestSelectorContainer.tsx
+++ b/src/pages/PRSelector/PullRequestSelectorContainer.tsx
@@ -13,7 +13,7 @@ interface PullRequestSelectorContainerProps {
 const PullRequestSelectorContainer: React.FC<
   PullRequestSelectorContainerProps
 > = ({ onSelect, initialPrId }) => {
-  const { data, loading, error } = usePullRequests();
+  const { data, loading, error, updateData } = usePullRequests();
 
   if (loading) {
     return (
@@ -45,6 +45,7 @@ const PullRequestSelectorContainer: React.FC<
       pullRequests={data}
       onSelect={onSelect}
       initialPrId={initialPrId}
+      updateData={updateData}
     />
   );
 };

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,4 +1,4 @@
-export const MAIN_COLOR = "#191970";
+export const MAIN_COLOR = "#5656c4";
 export const TABLE_HEADER_COLOR = "#D3D3D3";
 
 export const DIFF_ADDED_LINE_COLOR = "#9AFF9A";


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
PullRequestSelectorContainer_("PullRequestSelectorContainer"):::modified
usePullRequests_("usePullRequests"):::modified
PullRequestSelector_("PullRequestSelector"):::modified
PullRequestCard_("PullRequestCard"):::added
useFetchUser_("useFetchUser"):::added
MergeConfirmationPrompt_("MergeConfirmationPrompt"):::added
appMode_mode_dataProvider_("appMode.mode.dataProvider"):::added
PullRequestSelectorContainer_ -- "Added updateData to manage pull request data updates." --> usePullRequests_
PullRequestSelectorContainer_ -- "Passes updateData prop to PullRequestSelector for data updates." --> PullRequestSelector_
PullRequestSelector_ -- "Uses PullRequestCard to render detailed pull request info." --> PullRequestCard_
PullRequestSelector_ -- "Fetches current user data for display and logic." --> useFetchUser_
PullRequestSelector_ -- "Adds merge confirmation UI and logic." --> MergeConfirmationPrompt_
MergeConfirmationPrompt_ -- "Uses dataProvider to fetch merge status and merge PR." --> appMode_mode_dataProvider_
usePullRequests_ -- "Uses dataProvider to fetch pull requests list." --> appMode_mode_dataProvider_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhance the pull request data model and fetching mechanisms to include CI run statuses and code review information, refactoring <code>github.ts</code> to use GraphQL for richer data. Introduce new UI components, <code>PullRequestCard</code> and <code>MergeConfirmationPrompt</code>, to display this detailed information and enable direct merging of pull requests from the <code>PullRequestSelector</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/94?tool=ast&topic=PR+UI+%26+Merging>PR UI & Merging</a>
        </td><td>Implement a new <code>PullRequestCard</code> component to display detailed CI and review statuses, and introduce an interactive <code>MergeConfirmationPrompt</code> to allow users to merge pull requests directly from the <code>PullRequestSelector</code>.<details><summary>Modified files (6)</summary><ul><li>src/theme/colors.ts</li>
<li>src/pages/PRSelector/PullRequestSelectorContainer.tsx</li>
<li>src/pages/PRSelector/PullRequestSelector.tsx</li>
<li>src/pages/PRSelector/PullRequestCard.tsx</li>
<li>src/pages/PRSelector/MergeConfirmationPrompt.tsx</li>
<li>src/hooks/usePullRequests.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>feat-Support-tokens-mo...</td><td>December 08, 2025</td></tr>
<tr><td>nimrod@baz.co</td><td>feat-Skip-repo-selecti...</td><td>November 24, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/94?tool=ast&topic=Enhance+PR+Data>Enhance PR Data</a>
        </td><td>Update the <code>PullRequest</code> data model to include CI run statuses and code review information, and refactor data providers in <code>github.ts</code> and <code>baz.ts</code> to fetch this enriched data using GraphQL for GitHub.<details><summary>Modified files (4)</summary><ul><li>src/lib/providers/types.ts</li>
<li>src/lib/clients/github.ts</li>
<li>src/lib/clients/baz.ts</li>
<li>src/hooks/usePullRequests.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>feat-Migrate-conversat...</td><td>December 24, 2025</td></tr>
<tr><td>ofir@baz.co</td><td>feat-stop-agent-after-...</td><td>December 23, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/94?tool=ast>(Baz)</a>.