### PR TITLE
feat: handle new walkthrough data

### DIFF
--- a/src/lib/clients/baz.ts
+++ b/src/lib/clients/baz.ts
@@ -81,6 +81,7 @@ export interface LatestConversation {
   relatedEntityId: string;
   messageCount: number;
   messages: ChatMessage[];
+  newDataAvailable?: boolean;
 }
 
 export interface RepositoriesResponse {

--- a/src/pages/PRWalkthrough/UpdateAvailablePrompt.tsx
+++ b/src/pages/PRWalkthrough/UpdateAvailablePrompt.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+
+type UserChoice = "continue" | "startNew";
+
+interface UpdateAvailablePromptProps {
+  onSelect: (choice: UserChoice) => void;
+}
+
+interface SelectItem {
+  label: string;
+  value: UserChoice;
+}
+
+const UpdateAvailablePrompt: React.FC<UpdateAvailablePromptProps> = ({
+  onSelect,
+}) => {
+  const items: SelectItem[] = [
+    { label: "Continue existing walkthrough session", value: "continue" },
+    { label: "Start a new walkthrough with updated data", value: "startNew" },
+  ];
+
+  const handleSelect = (item: SelectItem) => {
+    onSelect(item.value);
+  };
+
+  return (
+    <Box flexDirection="column">
+      <Box marginBottom={1}>
+        <Text bold color="cyan">
+          The pull request has been updated since your last review. How would
+          you like to proceed?
+        </Text>
+      </Box>
+      <SelectInput
+        items={items}
+        onSelect={handleSelect}
+        indicatorComponent={({ isSelected }) => (
+          <Text color={isSelected ? "green" : "gray"}>
+            {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
+          </Text>
+        )}
+        itemComponent={({ isSelected, label }) => (
+          <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+        )}
+      />
+      <Box marginTop={1}>
+        <Text dimColor italic>
+          Use ↑↓ arrows and Enter to select
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export default UpdateAvailablePrompt;


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
PRWalkthrough_userChoice_("PRWalkthrough.userChoice"):::modified
UpdateAvailablePrompt_("UpdateAvailablePrompt"):::added
PRWalkthrough_userChoice_ -- "Prompts user choice on updated PR data availability." --> UpdateAvailablePrompt_
UpdateAvailablePrompt_ -- "Updates userChoice state via onSelect callback." --> PRWalkthrough_userChoice_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Introduces a feature to detect updated pull request data during a walkthrough session, prompting users within the <code>PRWalkthrough</code> component to choose between continuing an existing session or starting a new one via the new <code>UpdateAvailablePrompt</code> component. This functionality is supported by a <code>newDataAvailable</code> flag added to the <code>LatestConversation</code> interface.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/96?tool=ast&topic=Update+Data+Model>Update Data Model</a>
        </td><td>Extends the <code>LatestConversation</code> interface to include a <code>newDataAvailable</code> flag, indicating if the associated pull request has been updated.<details><summary>Modified files (1)</summary><ul><li>src/lib/clients/baz.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>feat-Ready-to-merge-94</td><td>December 28, 2025</td></tr>
<tr><td>ofir@baz.co</td><td>feat-stop-agent-after-...</td><td>December 23, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/baz-cli/96?tool=ast&topic=Handle+PR+Updates>Handle PR Updates</a>
        </td><td>Implements a user flow in the <code>PRWalkthrough</code> component to detect updated pull request data and present an <code>UpdateAvailablePrompt</code> to the user, allowing them to choose between continuing the current session or starting a new one.<details><summary>Modified files (2)</summary><ul><li>src/pages/PRWalkthrough/UpdateAvailablePrompt.tsx</li>
<li>src/pages/PRWalkthrough/PRWalkthrough.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>feat-Migrate-conversat...</td><td>December 24, 2025</td></tr>
<tr><td>anton.gruebel@gmail.com</td><td>feat-add-option-to-Cha...</td><td>December 14, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/baz-cli/96?tool=ast>(Baz)</a>.