### PR TITLE
feat: Add support for review of local changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,23 @@
+# App mode: set both GH_TOKEN and ANTHROPIC_TOKEN for "tokens" mode.
+# Leave both unset to use "baz" mode (OAuth authentication).
+GH_TOKEN=
+ANTHROPIC_TOKEN=
+
+# Baz service URL
+BAZ_BASE_URL=https://baz.co
+
+# Descope authentication
+DESCOPE_BASE_URL=https://api.descope.com
 DESCOPE_PROJECT_ID=
 DESCOPE_CLIENT_ID=
+
+# OAuth callback port for local auth flow
+OAUTH_CALLBACK_PORT=8020
+
+# Integration client IDs
+JIRA_CLIENT_ID=
+LINEAR_CLIENT_ID=
+
+# Environment
+NODE_ENV=production
+LOG_LEVEL=warn

--- a/src/flows/LocalReview/LocalDiffPrompt.tsx
+++ b/src/flows/LocalReview/LocalDiffPrompt.tsx
@@ -1,0 +1,125 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+import {
+  hasStagedChanges,
+  getUnstagedFiles,
+  getStagedDiff,
+  getAllDiff,
+} from "../../lib/git.js";
+
+type DiffChoice = "staged" | "all";
+
+interface SelectItem {
+  label: string;
+  value: DiffChoice;
+}
+
+interface LocalDiffPromptProps {
+  onReady: (diffText: string) => void;
+  onError: (message: string) => void;
+}
+
+const LocalDiffPrompt: React.FC<LocalDiffPromptProps> = ({
+  onReady,
+  onError,
+}) => {
+  const [unstagedFiles, setUnstagedFiles] = useState<string[]>([]);
+  const [hasStaged, setHasStaged] = useState(false);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    try {
+      const staged = hasStagedChanges();
+      const unstaged = getUnstagedFiles();
+
+      if (!staged && unstaged.length === 0) {
+        onError(
+          "No changes detected. Stage some changes with `git add` and try again.",
+        );
+        return;
+      }
+
+      setHasStaged(staged);
+      setUnstagedFiles(unstaged);
+
+      // Auto-proceed if no unstaged files
+      if (unstaged.length === 0) {
+        onReady(getStagedDiff());
+        return;
+      }
+
+      // If no staged changes but there are unstaged, auto-select all
+      if (!staged) {
+        onReady(getAllDiff());
+        return;
+      }
+
+      setReady(true);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : "Failed to read git state");
+    }
+  }, []);
+
+  if (!ready) {
+    return null;
+  }
+
+  const items: SelectItem[] = [
+    { label: "Review only staged changes", value: "staged" },
+    { label: "Review all changes (staged + unstaged)", value: "all" },
+  ];
+
+  const handleSelect = (item: SelectItem) => {
+    if (item.value === "staged") {
+      onReady(getStagedDiff());
+    } else {
+      onReady(getAllDiff());
+    }
+  };
+
+  return (
+    <Box flexDirection="column">
+      <Box flexDirection="column" marginBottom={1}>
+        <Text color="yellow" bold>
+          The following files have unstaged changes:
+        </Text>
+        {unstagedFiles.map((file) => (
+          <Text key={file} color="yellow">
+            {"  "}- {file}
+          </Text>
+        ))}
+      </Box>
+
+      {hasStaged && (
+        <>
+          <Box marginBottom={1}>
+            <Text>How would you like to proceed?</Text>
+          </Box>
+
+          <SelectInput
+            items={items}
+            onSelect={handleSelect}
+            indicatorComponent={({ isSelected }) => (
+              <Text color={isSelected ? "green" : "gray"}>
+                {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
+              </Text>
+            )}
+            itemComponent={({ isSelected, label }) => (
+              <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+            )}
+          />
+
+          <Box marginTop={1}>
+            <Text dimColor italic>
+              Use ↑↓ arrows and Enter to select
+            </Text>
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default LocalDiffPrompt;

--- a/src/flows/LocalReview/LocalPullRequestReview.tsx
+++ b/src/flows/LocalReview/LocalPullRequestReview.tsx
@@ -1,0 +1,146 @@
+import React, { useState, useCallback } from "react";
+import ReviewMenu, {
+  ReviewMenuAction,
+  CompletedSteps,
+} from "../Review/ReviewMenu.js";
+import PRChat from "../../pages/PRChat/PRChat.js";
+import { IssueType, CheckoutChatRequest } from "../../models/chat.js";
+
+const LOCAL_WALKTHROUGH_PROMPT =
+  "Please walk me through these changes. Start by showing me a very short description of what the changes do, followed by a brief summary of the sections. Do not include any section yet in your answer";
+
+interface LocalPullRequestReviewProps {
+  diffText: string;
+  repoName: string;
+  onComplete: () => void;
+  onBack: () => void;
+}
+
+type State =
+  | ({ step: "menu" } & MenuStateData)
+  | ({ step: "prWalkthrough" } & MenuStateData)
+  | ({ step: "prChat" } & MenuStateData & { chatInput?: string })
+  | { step: "complete" };
+
+interface MenuStateData {
+  completedSteps: CompletedSteps;
+}
+
+const LOCAL_PR_ID = "local";
+const LOCAL_PR_NUMBER = 0;
+
+const LocalPullRequestReview: React.FC<LocalPullRequestReviewProps> = ({
+  diffText,
+  repoName,
+  onComplete,
+  onBack,
+}) => {
+  const initialCompletedSteps: CompletedSteps = {
+    unmetRequirements: false,
+    metRequirements: false,
+    comments: false,
+    prWalkthrough: false,
+  };
+
+  const [state, setState] = useState<State>({
+    step: "menu",
+    completedSteps: initialCompletedSteps,
+  });
+
+  const buildLocalChatRequest = useCallback(
+    (freeText: string, conversationId?: string): CheckoutChatRequest => {
+      return {
+        mode: "local",
+        repoName,
+        diff: Buffer.from(diffText).toString("base64"),
+        diffEncoding: "base64",
+        issue: {
+          type: IssueType.PR_WALKTHROUGH,
+          data: { id: LOCAL_PR_ID },
+        },
+        freeText,
+        conversationId,
+      };
+    },
+    [repoName, diffText],
+  );
+
+  const handleMenuAction = (action: ReviewMenuAction, input?: string) => {
+    if (state.step !== "menu") return;
+
+    switch (action) {
+      case "prWalkthrough":
+        setState({ ...state, step: "prWalkthrough" });
+        break;
+      case "prChat":
+        setState({ ...state, chatInput: input, step: "prChat" });
+        break;
+      case "finish":
+        setState({ step: "complete" });
+        onComplete();
+        break;
+    }
+  };
+
+  const handleBackFromWalkthrough = () => {
+    if (state.step !== "prWalkthrough") return;
+    setState({
+      step: "menu",
+      completedSteps: { ...state.completedSteps, prWalkthrough: true },
+    });
+  };
+
+  const handleBackFromChat = () => {
+    if (state.step !== "prChat") return;
+    setState({ ...state, step: "menu" });
+  };
+
+  const handleBackFromMenu = () => {
+    onBack();
+  };
+
+  switch (state.step) {
+    case "menu":
+      return (
+        <ReviewMenu
+          unmetRequirementsCount={0}
+          metRequirementsCount={0}
+          unresolvedCommentsCount={0}
+          completedSteps={state.completedSteps}
+          onSelect={handleMenuAction}
+          onBack={handleBackFromMenu}
+        />
+      );
+    case "prWalkthrough":
+      return (
+        <PRChat
+          issueType={IssueType.PR_WALKTHROUGH}
+          prId={LOCAL_PR_ID}
+          fullRepoName={repoName}
+          prNumber={LOCAL_PR_NUMBER}
+          chatTitle="Local Changes Walkthrough"
+          chatDescription="Walkthrough of local changes. Press ESC to go back."
+          chatInput={LOCAL_WALKTHROUGH_PROMPT}
+          outputInitialMessage={false}
+          buildChatRequestOverride={buildLocalChatRequest}
+          onBack={handleBackFromWalkthrough}
+        />
+      );
+    case "prChat":
+      return (
+        <PRChat
+          issueType={IssueType.PR_CHAT}
+          prId={LOCAL_PR_ID}
+          fullRepoName={repoName}
+          prNumber={LOCAL_PR_NUMBER}
+          chatInput={state.chatInput}
+          buildChatRequestOverride={buildLocalChatRequest}
+          onBack={handleBackFromChat}
+        />
+      );
+    case "complete":
+      return null;
+  }
+};
+
+export default LocalPullRequestReview;

--- a/src/flows/Review/Review.tsx
+++ b/src/flows/Review/Review.tsx
@@ -7,6 +7,9 @@ import IntegrationsCheck from "../Integration/IntegrationsCheck.js";
 import PostReviewPrompt, { PostReviewAction } from "./PostReviewPrompt.js";
 import { logger } from "../../lib/logger.js";
 import PullRequestReview from "../../components/PullRequestReview.js";
+import LocalDiffPrompt from "../LocalReview/LocalDiffPrompt.js";
+import LocalPullRequestReview from "../LocalReview/LocalPullRequestReview.js";
+import { getRepoName } from "../../lib/git.js";
 import { MAIN_COLOR } from "../../theme/colors.js";
 import { REVIEW_COMPLETE_TEXT } from "../../theme/banners.js";
 import { useAppMode } from "../../lib/config/index.js";
@@ -45,12 +48,26 @@ type FlowState =
       step: "complete";
       selectedPR: PullRequest;
       skippedIntegration?: boolean;
+    }
+  | {
+      step: "localDiffPrompt";
+    }
+  | {
+      step: "localReview";
+      diffText: string;
+    }
+  | {
+      step: "localReviewComplete";
     };
 
-const InternalReviewFlow: React.FC = () => {
-  const [flowState, setFlowState] = useState<FlowState>({
-    step: "handlePRSelect",
-  });
+interface InternalReviewFlowProps {
+  isLocal?: boolean;
+}
+
+const InternalReviewFlow: React.FC<InternalReviewFlowProps> = ({ isLocal }) => {
+  const [flowState, setFlowState] = useState<FlowState>(
+    isLocal ? { step: "localDiffPrompt" } : { step: "handlePRSelect" },
+  );
   const [hasIntegration, setHasIntegration] = useState<boolean | null>(null);
   const appMode = useAppMode();
 
@@ -163,12 +180,42 @@ const InternalReviewFlow: React.FC = () => {
     });
   };
 
+  // Local review handlers
+  const handleLocalSelect = () => {
+    setFlowState({ step: "localDiffPrompt" });
+  };
+
+  const handleLocalDiffReady = (diffText: string) => {
+    setFlowState({ step: "localReview", diffText });
+  };
+
+  const handleLocalDiffError = (message: string) => {
+    // Fall back to PR selector with error shown
+    logger.debug({ message }, "Local diff error");
+    setFlowState({ step: "handlePRSelect" });
+  };
+
+  const handleLocalReviewComplete = () => {
+    setFlowState({ step: "localReviewComplete" });
+  };
+
+  const handleLocalReviewBack = () => {
+    if (isLocal) {
+      // If launched with --local, go back to diff prompt
+      setFlowState({ step: "localDiffPrompt" });
+    } else {
+      // If entered from PR selector, go back to selector
+      setFlowState({ step: "handlePRSelect" });
+    }
+  };
+
   switch (flowState.step) {
     case "handlePRSelect":
       return (
         <Box flexDirection="column">
           <PullRequestSelectorContainer
             onSelect={handlePRSelect}
+            onLocalSelect={handleLocalSelect}
             initialPrId={flowState.selectedPR?.id}
           />
         </Box>
@@ -209,6 +256,42 @@ const InternalReviewFlow: React.FC = () => {
     case "complete":
       return <CompleteMessage flowState={flowState} />;
 
+    case "localDiffPrompt":
+      return (
+        <Box flexDirection="column">
+          <LocalDiffPrompt
+            onReady={handleLocalDiffReady}
+            onError={handleLocalDiffError}
+          />
+        </Box>
+      );
+
+    case "localReview":
+      return (
+        <Box flexDirection="column">
+          <Box marginBottom={1}>
+            <Text color="green">✓ Reviewing local changes </Text>
+            <Text color="yellow">[{getRepoName()}]</Text>
+          </Box>
+          <LocalPullRequestReview
+            diffText={flowState.diffText}
+            repoName={getRepoName()}
+            onComplete={handleLocalReviewComplete}
+            onBack={handleLocalReviewBack}
+          />
+        </Box>
+      );
+
+    case "localReviewComplete":
+      return (
+        <Box flexDirection="column">
+          <Box flexDirection="column" marginBottom={1}>
+            <Text color={MAIN_COLOR}>{REVIEW_COMPLETE_TEXT}</Text>
+            <Text>Local review completed</Text>
+          </Box>
+        </Box>
+      );
+
     default:
       return <Text color="red">Unknown step</Text>;
   }
@@ -242,11 +325,15 @@ const CompleteMessage: React.FC<{
   );
 };
 
-const ReviewFlow = () => (
+interface ReviewFlowProps {
+  isLocal?: boolean;
+}
+
+const ReviewFlow: React.FC<ReviewFlowProps> = ({ isLocal }) => (
   <>
     <HeaderDisplay />
 
-    <InternalReviewFlow />
+    <InternalReviewFlow isLocal={isLocal} />
   </>
 );
 export default ReviewFlow;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@ program.name("Baz CLI").version(VERSION);
 program
   .command("review", { isDefault: true })
   .description("Start a review")
-  .action(async () => {
+  .option("--local", "Review local git changes instead of a GitHub PR")
+  .action(async (options: { local?: boolean }) => {
     try {
       getAppConfig(); // Validate early before rendering
     } catch (e) {
@@ -44,7 +45,7 @@ program
       React.createElement(
         AppModeProvider,
         null,
-        React.createElement(ReviewFlow),
+        React.createElement(ReviewFlow, { isLocal: options.local }),
       ),
     );
   });

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,0 +1,103 @@
+import { execSync } from "child_process";
+import path from "path";
+
+const EXEC_OPTIONS = { encoding: "utf-8" as const, maxBuffer: 10 * 1024 * 1024 };
+
+function gitExec(args: string): string {
+  try {
+    return execSync(`git ${args}`, EXEC_OPTIONS).trim();
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("not a git repository")
+    ) {
+      throw new Error(
+        "Not a git repository. Run this command from within a git project.",
+      );
+    }
+    throw error;
+  }
+}
+
+export function getStagedDiff(): string {
+  return gitExec("diff --cached");
+}
+
+export function getUnstagedFiles(): string[] {
+  const output = gitExec("diff --name-only");
+  return output ? output.split("\n") : [];
+}
+
+export function getAllDiff(): string {
+  return gitExec("diff HEAD");
+}
+
+export function getRepoName(): string {
+  try {
+    const remoteUrl = gitExec("remote get-url origin");
+
+    // SSH format: git@github.com:org/repo.git
+    const sshMatch = remoteUrl.match(/git@[^:]+:(.+?)(?:\.git)?$/);
+    if (sshMatch) return sshMatch[1];
+
+    // HTTPS format: https://github.com/org/repo.git
+    const httpsMatch = remoteUrl.match(/https?:\/\/[^/]+\/(.+?)(?:\.git)?$/);
+    if (httpsMatch) return httpsMatch[1];
+
+    return remoteUrl;
+  } catch {
+    return path.basename(process.cwd());
+  }
+}
+
+export function hasStagedChanges(): boolean {
+  return getStagedDiff().length > 0;
+}
+
+export interface ChangeSummary {
+  modified: number;
+  added: number;
+  deleted: number;
+}
+
+export function getChangeSummary(): ChangeSummary | null {
+  const staged = gitExec("diff --cached --name-status");
+  const unstaged = gitExec("diff --name-status");
+
+  // Combine and deduplicate by filename (staged takes precedence)
+  const fileStatuses = new Map<string, string>();
+  for (const line of [...unstaged.split("\n"), ...staged.split("\n")]) {
+    if (!line.trim()) continue;
+    const [status, ...fileParts] = line.split("\t");
+    const file = fileParts.join("\t");
+    if (status && file) {
+      fileStatuses.set(file, status.charAt(0));
+    }
+  }
+
+  if (fileStatuses.size === 0) return null;
+
+  let modified = 0;
+  let added = 0;
+  let deleted = 0;
+
+  for (const status of fileStatuses.values()) {
+    switch (status) {
+      case "A":
+        added++;
+        break;
+      case "D":
+        deleted++;
+        break;
+      default:
+        modified++;
+        break;
+    }
+  }
+
+  return { modified, added, deleted };
+}
+
+export function hasAnyChanges(): boolean {
+  return getChangeSummary() !== null;
+}

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,7 +1,10 @@
 import { execSync } from "child_process";
 import path from "path";
 
-const EXEC_OPTIONS = { encoding: "utf-8" as const, maxBuffer: 10 * 1024 * 1024 };
+const EXEC_OPTIONS = {
+  encoding: "utf-8" as const,
+  maxBuffer: 10 * 1024 * 1024,
+};
 
 function gitExec(args: string): string {
   try {

--- a/src/models/chat.ts
+++ b/src/models/chat.ts
@@ -102,7 +102,20 @@ export interface TokensChatRequest {
   conversationId?: string;
 }
 
-export type CheckoutChatRequest = BazChatRequest | TokensChatRequest;
+export interface LocalChatRequest {
+  mode: "local";
+  repoName: string;
+  diff: string;
+  diffEncoding: "base64";
+  issue: ChatIssue;
+  freeText: string;
+  conversationId?: string;
+}
+
+export type CheckoutChatRequest =
+  | BazChatRequest
+  | TokensChatRequest
+  | LocalChatRequest;
 
 export interface MessageStart {
   type: "message_start";

--- a/src/pages/PRChat/PRChat.tsx
+++ b/src/pages/PRChat/PRChat.tsx
@@ -8,7 +8,7 @@ import {
 } from "../../models/chat.js";
 import { processStream, StreamAbortError } from "../../lib/chat-stream.js";
 import { MAIN_COLOR } from "../../theme/colors.js";
-import { useAppMode } from "../../lib/config/AppModeContext.js";
+import { useAppMode } from "../../lib/config/index.js";
 
 interface PRChatProps {
   prId: string;
@@ -22,6 +22,10 @@ interface PRChatProps {
   issueType: IssueType.PR_CHAT | IssueType.PR_WALKTHROUGH;
   existingMessages?: ChatMessage[];
   existingConversationId?: string;
+  buildChatRequestOverride?: (
+    freeText: string,
+    conversationId?: string,
+  ) => CheckoutChatRequest;
   onBack: () => void;
 }
 
@@ -37,6 +41,7 @@ const PRChat: React.FC<PRChatProps> = ({
   issueType,
   existingMessages,
   existingConversationId,
+  buildChatRequestOverride,
   onBack,
 }) => {
   const [conversationId, setConversationId] = useState<string | undefined>(
@@ -56,6 +61,10 @@ const PRChat: React.FC<PRChatProps> = ({
 
   const buildChatRequest = useCallback(
     (freeText: string, convId?: string): CheckoutChatRequest => {
+      if (buildChatRequestOverride) {
+        return buildChatRequestOverride(freeText, convId);
+      }
+
       const issue = {
         type: issueType,
         data: { id: prId },
@@ -80,7 +89,14 @@ const PRChat: React.FC<PRChatProps> = ({
         conversationId: convId,
       };
     },
-    [appMode.mode.name, bazRepoId, prId, fullRepoName, prNumber],
+    [
+      appMode.mode.name,
+      bazRepoId,
+      prId,
+      fullRepoName,
+      prNumber,
+      buildChatRequestOverride,
+    ],
   );
 
   const runChatStream = useCallback(

--- a/src/pages/PRSelector/PullRequestSelector.tsx
+++ b/src/pages/PRSelector/PullRequestSelector.tsx
@@ -208,10 +208,7 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
                   Review local changes
                 </Text>
                 {changeSummary && (
-                  <Text dimColor>
-                    {" "}
-                    ({formatChangeSummary(changeSummary)})
-                  </Text>
+                  <Text dimColor> ({formatChangeSummary(changeSummary)})</Text>
                 )}
               </Box>
             )}

--- a/src/pages/PRSelector/PullRequestSelector.tsx
+++ b/src/pages/PRSelector/PullRequestSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import { Box, Text, useInput } from "ink";
 import type { PullRequest } from "../../lib/providers/index.js";
+import type { ChangeSummary } from "../../lib/git.js";
 import { updatedTimeAgo } from "../../lib/date.js";
 import { PullRequestCard } from "./PullRequestCard.js";
 import { useFetchUser } from "../../hooks/useFetchUser.js";
@@ -17,13 +18,19 @@ interface PullRequestSearchKeywords {
 interface PullRequestSelectorProps {
   pullRequests: PullRequest[];
   onSelect: (pr: PullRequest) => void;
+  onLocalSelect?: () => void;
+  changeSummary?: ChangeSummary;
   initialPrId?: string;
   updateData: (updater: (prev: PullRequest[]) => PullRequest[]) => void;
 }
 
+const LOCAL_CHANGES_INDEX = -1;
+
 const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
   pullRequests,
   onSelect,
+  onLocalSelect,
+  changeSummary,
   initialPrId,
   updateData,
 }) => {
@@ -44,12 +51,17 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
       updatedAt: updatedTimeAgo(pr.updatedAt),
     }));
 
+  const hasLocal = !!onLocalSelect;
+  const minIndex = hasLocal ? LOCAL_CHANGES_INDEX : 0;
+
   const initialIndex = initialPrId
     ? sanitizedPRs.findIndex((pr) => pr.id === initialPrId)
-    : 0;
+    : hasLocal
+      ? LOCAL_CHANGES_INDEX
+      : 0;
 
   const [selectedIndex, setSelectedIndex] = useState(
-    initialIndex >= 0 ? initialIndex : 0,
+    initialIndex >= minIndex ? initialIndex : minIndex,
   );
 
   const searchKeywords = extractSearchKeywords(searchQuery.toLowerCase());
@@ -85,7 +97,7 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
       isFirstRender.current = false;
       return;
     }
-    setSelectedIndex(0);
+    setSelectedIndex(searchQuery ? 0 : minIndex);
   }, [searchQuery]);
 
   useInput((input, key) => {
@@ -94,7 +106,7 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
     }
 
     if (key.upArrow) {
-      setSelectedIndex((prev) => Math.max(0, prev - 1));
+      setSelectedIndex((prev) => Math.max(minIndex, prev - 1));
     } else if (key.downArrow) {
       setSelectedIndex((prev) => Math.min(filteredPRs.length - 1, prev + 1));
     } else if (key.return) {
@@ -112,7 +124,11 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
   });
 
   const handleSubmit = () => {
-    if (filteredPRs.length > 0) {
+    if (selectedIndex === LOCAL_CHANGES_INDEX && onLocalSelect) {
+      onLocalSelect();
+      return;
+    }
+    if (filteredPRs.length > 0 && selectedIndex >= 0) {
       onSelect(filteredPRs[selectedIndex]);
     }
   };
@@ -126,7 +142,8 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
     );
   };
 
-  const selectedPr = filteredPRs[selectedIndex];
+  const selectedPr =
+    selectedIndex >= 0 ? filteredPRs[selectedIndex] : undefined;
   const canMergeSelectedPr = selectedPr ? canMergePR(selectedPr) : false;
 
   if (showMergePrompt && prToMerge) {
@@ -179,6 +196,25 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
           <Text color="yellow">No pull requests match your search.</Text>
         ) : (
           <>
+            {hasLocal && (
+              <Box marginBottom={1}>
+                <Text
+                  color={
+                    selectedIndex === LOCAL_CHANGES_INDEX ? "cyan" : "gray"
+                  }
+                  bold={selectedIndex === LOCAL_CHANGES_INDEX}
+                >
+                  {selectedIndex === LOCAL_CHANGES_INDEX ? "❯ " : "  "}
+                  Review local changes
+                </Text>
+                {changeSummary && (
+                  <Text dimColor>
+                    {" "}
+                    ({formatChangeSummary(changeSummary)})
+                  </Text>
+                )}
+              </Box>
+            )}
             <Text dimColor>
               Found {filteredPRs.length}{" "}
               {filteredPRs.length === 1 ? "pull request" : "pull requests"}:
@@ -284,6 +320,20 @@ function extractSearchKeywords(query: string): PullRequestSearchKeywords {
   }
 
   return { author, authorNot, repo, repoNot, freetext: freeText.join(" ") };
+}
+
+function formatChangeSummary(summary: ChangeSummary): string {
+  const parts: string[] = [];
+  if (summary.modified > 0) {
+    parts.push(`${summary.modified} modified`);
+  }
+  if (summary.added > 0) {
+    parts.push(`${summary.added} added`);
+  }
+  if (summary.deleted > 0) {
+    parts.push(`${summary.deleted} deleted`);
+  }
+  return parts.join(", ");
 }
 
 export default PullRequestSelector;

--- a/src/pages/PRSelector/PullRequestSelectorContainer.tsx
+++ b/src/pages/PRSelector/PullRequestSelectorContainer.tsx
@@ -1,19 +1,32 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Box, Text, useInput } from "ink";
 import Spinner from "ink-spinner";
 import type { PullRequest } from "../../lib/providers/index.js";
 import { usePullRequests } from "../../hooks/usePullRequests.js";
+import { getChangeSummary, type ChangeSummary } from "../../lib/git.js";
 import PullRequestSelector from "./PullRequestSelector.js";
 
 interface PullRequestSelectorContainerProps {
   onSelect: (pr: PullRequest) => void;
+  onLocalSelect?: () => void;
   initialPrId?: string;
 }
 
 const PullRequestSelectorContainer: React.FC<
   PullRequestSelectorContainerProps
-> = ({ onSelect, initialPrId }) => {
+> = ({ onSelect, onLocalSelect, initialPrId }) => {
   const { data, loading, error, updateData } = usePullRequests();
+  const [changeSummary, setChangeSummary] = useState<ChangeSummary | null>(
+    null,
+  );
+
+  useEffect(() => {
+    try {
+      setChangeSummary(getChangeSummary());
+    } catch {
+      // Not a git repo or git not available — don't show local option
+    }
+  }, []);
 
   if (loading) {
     return (
@@ -44,6 +57,8 @@ const PullRequestSelectorContainer: React.FC<
     <PullRequestSelector
       pullRequests={data}
       onSelect={onSelect}
+      onLocalSelect={changeSummary ? onLocalSelect : undefined}
+      changeSummary={changeSummary ?? undefined}
       initialPrId={initialPrId}
       updateData={updateData}
     />


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable local diff reviews by wiring <code>ReviewFlow</code> to new <code>LocalDiffPrompt</code> and <code>LocalPullRequestReview</code>, which now feed diffs into <code>PRChat</code> via <code>CheckoutChatRequest</code> overrides and the <code>--local</code> CLI flag to bootstrap the experience. Document local-mode defaults while surfacing git metadata through <code>lib/git</code> so the selector UI can show change summaries and drive the local-review entry point.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/baz-cli/109?tool=ast&topic=Git+info+surface>Git info surface</a>
        </td><td>Expose git command helpers and change summaries (plus <code>.env</code> defaults) so the selector UI can depict unstaged/staged changes, offer the local-review slot, and keep <code>PullRequestSelectorContainer</code> aware of git state before handing control to the new flow.<details><summary>Modified files (4)</summary><ul><li>.env.example</li>
<li>src/lib/git.ts</li>
<li>src/pages/PRSelector/PullRequestSelector.tsx</li>
<li>src/pages/PRSelector/PullRequestSelectorContainer.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yuvalyacoby</td><td>feat: Ready to merge (...</td><td>December 28, 2025</td></tr>
<tr><td>anton.gruebel@gmail.com</td><td>feat: add include and ...</td><td>December 18, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://main.baz.ninja/changes/baz-scm/baz-cli/109?tool=ast&topic=Local+review+flow>Local review flow</a>
        </td><td>Orchestrate the local-review experience by introducing <code>LocalDiffPrompt</code>, <code>LocalPullRequestReview</code>, and the new CLI flag to prime <code>ReviewFlow</code>; feed diffs into <code>PRChat</code> (with overrides defined in <code>models/chat</code>) and signal completion/back-navigation through the existing menu flow so local changes can be reviewed just like a PR.<details><summary>Modified files (6)</summary><ul><li>src/flows/LocalReview/LocalDiffPrompt.tsx</li>
<li>src/flows/LocalReview/LocalPullRequestReview.tsx</li>
<li>src/flows/Review/Review.tsx</li>
<li>src/index.ts</li>
<li>src/models/chat.ts</li>
<li>src/pages/PRChat/PRChat.tsx</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrod@baz.co</td><td>chore: Use PR consiste...</td><td>December 11, 2025</td></tr>
<tr><td>yuvalyacoby</td><td>feat: Full pr data imp...</td><td>December 09, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://main.baz.ninja/changes/baz-scm/baz-cli/109?tool=ast>(Baz)</a>.