### PR TITLE
fix: make comment review UI scrollable and dark-mode aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,13 @@ The same keys can live in a theme file, checked in this order:
 }
 ```
 
-Available keys: `main`, `accent`, `success`, `warning`, `error`, `info`,
+Available keys: `main`, `accent`, `text`, `success`, `warning`, `error`, `info`,
 `fileHeaderBg`, `fileHeaderFg`, `diffAddedBg`, `diffAddedFg`, `diffDeletedBg`,
 `diffDeletedFg`, `diffSelectedBg`, `diffSelectedFg`, `diffContextFg`,
-`lineNumberFg`. Environment variables win over the file. With colors off, the
-lines a comment points at are shown in bold instead.
+`lineNumberFg`. Environment variables win over the file, non-string values in
+the file are ignored, and a background is never used without a readable
+foreground - setting a `*Fg` key to `none` drops its background too. With
+colors off, the lines a comment points at are shown in bold instead.
 
 
 ## 🛠️ Development

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ While AI helps you write code at unprecedented speed, human reviewers still need
 - [Requirements](#requirements)
 - [Review Flow](#review-flow)
 - [Environment Variables](#environment-variables)
+- [Appearance](#appearance)
 - [Development](#-development)
 - [Contributing](#-contributing)
 - [Links](#-links)
@@ -137,6 +138,62 @@ The CLI respects the following environment variables:
 - If only one token is set → Error (both tokens required for standalone mode)
 
 Environment variables are read at runtime, so you can adjust them without rebuilding the CLI.
+
+---
+
+### Appearance
+
+#### Scrolling
+
+Review screens (comments, requirements, chat) fit themselves to the terminal
+window. When the comment, its diff and the conversation do not fit, the content
+area scrolls while the input box and its hints stay on screen:
+
+| Key | Action |
+| --- | --- |
+| `↑` / `↓` | Scroll one line |
+| `PgUp` / `PgDn` | Scroll one screen |
+| `Ctrl+U` / `Ctrl+D` | Scroll half a screen |
+
+A status line below the content shows the visible range, e.g.
+`↑↓ lines 12-30 of 84`. The view follows new chat output, unless you have
+scrolled up.
+
+#### Colors
+
+Colors adapt to the terminal background. Detection uses `COLORFGBG` where the
+terminal provides it and assumes a dark background otherwise.
+
+- `BAZ_THEME` – `auto` (default), `dark`, `light`, or `none` to disable colors
+- `BAZ_TERMINAL_BACKGROUND` – `dark` / `light`, overrides auto-detection only
+- `NO_COLOR` – any non-empty value disables colors ([no-color.org](https://no-color.org))
+
+Individual colors can be overridden with `BAZ_COLOR_*` variables, using a hex
+value or `none` to leave that element unstyled:
+
+```bash
+BAZ_COLOR_DIFF_ADDED_BG="#003300" BAZ_COLOR_MAIN=none baz review
+```
+
+The same keys can live in a theme file, checked in this order:
+`$BAZ_THEME_FILE`, `./.baz/theme.json`, `~/.baz/theme.json`,
+`~/.config/baz/theme.json`.
+
+```json
+{
+  "theme": "dark",
+  "main": "#9d9df0",
+  "diffAddedBg": "#1e3b26",
+  "diffAddedFg": "#b9f0c4",
+  "diffSelectedBg": "#4a4324"
+}
+```
+
+Available keys: `main`, `accent`, `success`, `warning`, `error`, `info`,
+`fileHeaderBg`, `fileHeaderFg`, `diffAddedBg`, `diffAddedFg`, `diffDeletedBg`,
+`diffDeletedFg`, `diffSelectedBg`, `diffSelectedFg`, `diffContextFg`,
+`lineNumberFg`. Environment variables win over the file. With colors off, the
+lines a comment points at are shown in bold instead.
 
 
 ## 🛠️ Development

--- a/src/components/DiffDisplay.tsx
+++ b/src/components/DiffDisplay.tsx
@@ -2,12 +2,9 @@ import React, { memo } from "react";
 import { Box, Text } from "ink";
 import type { FileDiff } from "../lib/providers/index.js";
 import { FileSelectionLines } from "../models/Diff.js";
-import {
-  DIFF_ADDED_LINE_COLOR,
-  DIFF_DELETED_LINE_COLOR,
-  DIFF_SELECTED_LINE_COLOR,
-  TABLE_HEADER_COLOR,
-} from "../theme/colors.js";
+import { getTheme, type TextStyle } from "../theme/theme.js";
+
+const theme = getTheme();
 
 const MAX_ADDED_VIEW_LINES = 3;
 const ADDED_LINE_PREFIX = "+";
@@ -18,50 +15,74 @@ interface DiffRowProps {
   leftNumber?: number;
   leftPrefix?: string;
   leftLine: string;
-  leftColor?: string;
+  leftStyle?: TextStyle;
   rightNumber?: number;
   rightPrefix?: string;
   rightLine: string;
-  rightColor?: string;
+  rightStyle?: TextStyle;
 }
+
+/**
+ * One side of a diff row.
+ *
+ * The background and the foreground are always set together - a background
+ * without a matching text color is what made these rows unreadable on dark
+ * terminals, since the terminal's own foreground stayed light.
+ */
+const DiffSide: React.FC<{
+  number?: number;
+  prefix?: string;
+  line: string;
+  style: TextStyle;
+}> = ({ number, prefix, line, style }) => (
+  <Box width="50%" backgroundColor={style.backgroundColor}>
+    <Text
+      color={style.color ?? theme.lineNumber.color}
+      backgroundColor={style.backgroundColor}
+      bold={style.bold}
+      dimColor={!style.color && !style.backgroundColor}
+    >
+      {(number ?? "").toString().padStart(5)}
+      {prefix ? ` ${prefix} ` : "   "}
+    </Text>
+    <Box>
+      <Text
+        color={style.color}
+        backgroundColor={style.backgroundColor}
+        bold={style.bold}
+      >
+        {line}
+      </Text>
+    </Box>
+  </Box>
+);
 
 const DiffRow = memo<DiffRowProps>(
   ({
     leftNumber,
     leftPrefix,
     leftLine,
-    leftColor,
+    leftStyle,
     rightNumber,
     rightPrefix,
     rightLine,
-    rightColor,
-  }) => {
-    const leftNum = (leftNumber ?? "").toString().padStart(5);
-    const rightNum = (rightNumber ?? "").toString().padStart(5);
-
-    return (
-      <Box>
-        <Box width="50%" backgroundColor={leftColor}>
-          <Text>
-            {leftNum}
-            {leftPrefix ? ` ${leftPrefix} ` : "   "}
-          </Text>
-          <Box>
-            <Text>{leftLine}</Text>
-          </Box>
-        </Box>
-        <Box width="50%" backgroundColor={rightColor}>
-          <Text>
-            {rightNum}
-            {rightPrefix ? ` ${rightPrefix} ` : "   "}
-          </Text>
-          <Box>
-            <Text>{rightLine}</Text>
-          </Box>
-        </Box>
-      </Box>
-    );
-  },
+    rightStyle,
+  }) => (
+    <Box>
+      <DiffSide
+        number={leftNumber}
+        prefix={leftPrefix}
+        line={leftLine}
+        style={leftStyle ?? theme.diffContext}
+      />
+      <DiffSide
+        number={rightNumber}
+        prefix={rightPrefix}
+        line={rightLine}
+        style={rightStyle ?? theme.diffContext}
+      />
+    </Box>
+  ),
 );
 
 // Memoized file header
@@ -71,10 +92,19 @@ interface FileHeaderProps {
 }
 
 const FileHeader = memo<FileHeaderProps>(({ filePath, outdated }) => (
-  <Box paddingX={1} backgroundColor={TABLE_HEADER_COLOR}>
-    <Text>{`☰ ${filePath}`}</Text>
+  <Box paddingX={1} backgroundColor={theme.fileHeader.backgroundColor}>
+    <Text
+      color={theme.fileHeader.color}
+      backgroundColor={theme.fileHeader.backgroundColor}
+      bold={theme.fileHeader.bold}
+    >{`☰ ${filePath}`}</Text>
     {outdated && (
-      <Text bold color="red">
+      <Text
+        bold
+        color={theme.error}
+        backgroundColor={theme.fileHeader.backgroundColor}
+      >
+        {" "}
         outdated
       </Text>
     )}
@@ -99,7 +129,7 @@ const DiffDisplayInternal: React.FC<DiffDisplayProps> = ({
 
         if (!selectionLines || selectionLines.end === undefined) {
           return (
-            <Text color="red">
+            <Text color={theme.error}>
               No range info for {file.diff.file_relative_path}
             </Text>
           );
@@ -160,36 +190,36 @@ const DiffDisplayInternal: React.FC<DiffDisplayProps> = ({
                   .map((line) => {
                     let leftPrefix = "";
                     let rightPrefix = "";
-                    let leftColor: string | undefined;
-                    let rightColor: string | undefined;
+                    let leftStyle: TextStyle | undefined;
+                    let rightStyle: TextStyle | undefined;
 
                     if (line.line_type === "Added") {
                       rightPrefix = ADDED_LINE_PREFIX;
-                      rightColor = DIFF_ADDED_LINE_COLOR;
+                      rightStyle = theme.diffAdded;
                     } else if (line.line_type === "Deleted") {
                       leftPrefix = DELETED_LINE_PREFIX;
-                      leftColor = DIFF_DELETED_LINE_COLOR;
+                      leftStyle = theme.diffDeleted;
                     } else if (line.line_type === "Changed") {
                       // in this case we have old and new content
                       if (line.content != null) {
                         leftPrefix = DELETED_LINE_PREFIX;
-                        leftColor = DIFF_DELETED_LINE_COLOR;
+                        leftStyle = theme.diffDeleted;
                       }
                       if (line.new_content != null) {
                         rightPrefix = ADDED_LINE_PREFIX;
-                        rightColor = DIFF_ADDED_LINE_COLOR;
+                        rightStyle = theme.diffAdded;
                       }
                     }
 
                     if (selectionSide === "left") {
                       const num = line.number ?? 0;
                       if (num >= selectionStart && num <= selectionEnd) {
-                        leftColor = DIFF_SELECTED_LINE_COLOR;
+                        leftStyle = theme.diffSelected;
                       }
                     } else {
                       const newNum = line.new_line_number ?? 0;
                       if (newNum >= selectionStart && newNum <= selectionEnd) {
-                        rightColor = DIFF_SELECTED_LINE_COLOR;
+                        rightStyle = theme.diffSelected;
                       }
                     }
 
@@ -199,11 +229,11 @@ const DiffDisplayInternal: React.FC<DiffDisplayProps> = ({
                         leftNumber={line.number}
                         leftPrefix={leftPrefix}
                         leftLine={line.content ?? ""}
-                        leftColor={leftColor}
+                        leftStyle={leftStyle}
                         rightNumber={line.new_line_number}
                         rightPrefix={rightPrefix}
                         rightLine={line.new_content ?? ""}
-                        rightColor={rightColor}
+                        rightStyle={rightStyle}
                       />
                     );
                   })}

--- a/src/components/DiffDisplay.tsx
+++ b/src/components/DiffDisplay.tsx
@@ -37,10 +37,12 @@ const DiffSide: React.FC<{
 }> = ({ number, prefix, line, style }) => (
   <Box width="50%" backgroundColor={style.backgroundColor}>
     <Text
-      color={style.color ?? theme.lineNumber.color}
+      // Gutters follow lineNumberFg, except on a highlighted row where the
+      // row's own foreground is what stays readable against its background.
+      color={style.backgroundColor ? style.color : theme.lineNumber.color}
       backgroundColor={style.backgroundColor}
       bold={style.bold}
-      dimColor={!style.color && !style.backgroundColor}
+      dimColor={!style.backgroundColor && !theme.lineNumber.color}
     >
       {(number ?? "").toString().padStart(5)}
       {prefix ? ` ${prefix} ` : "   "}

--- a/src/components/DiffDisplayContainer.tsx
+++ b/src/components/DiffDisplayContainer.tsx
@@ -49,7 +49,7 @@ const DiffDisplayContainer: React.FC<DiffDisplayContainerProps> = ({
   if (data.length === 0) {
     return (
       <Box flexDirection="column">
-        <Text color={theme.success}>✨ No diff related to issue!</Text>
+        <Text color={theme.success}>✨ No diff related to the issue!</Text>
       </Box>
     );
   }

--- a/src/components/DiffDisplayContainer.tsx
+++ b/src/components/DiffDisplayContainer.tsx
@@ -5,6 +5,9 @@ import { useFileDiffs } from "../hooks/useFileDiffs.js";
 import DiffDisplay from "./DiffDisplay.js";
 import { FileSelectionLines } from "../models/Diff.js";
 import type { PRContext } from "../lib/providers/index.js";
+import { getTheme } from "../theme/theme.js";
+
+const theme = getTheme();
 
 interface DiffDisplayContainerProps {
   prContext: PRContext;
@@ -25,10 +28,10 @@ const DiffDisplayContainer: React.FC<DiffDisplayContainerProps> = ({
   if (loading) {
     return (
       <Box>
-        <Text color="blue">
+        <Text color={theme.info}>
           <Spinner type="dots" />
         </Text>
-        <Text color="blue"> Fetching diff...</Text>
+        <Text color={theme.info}> Fetching diff...</Text>
       </Box>
     );
   }
@@ -36,7 +39,7 @@ const DiffDisplayContainer: React.FC<DiffDisplayContainerProps> = ({
   if (error) {
     return (
       <Box flexDirection="column">
-        <Text color="red" bold>
+        <Text color={theme.error} bold>
           ❌ Error: {error}
         </Text>
       </Box>
@@ -46,7 +49,7 @@ const DiffDisplayContainer: React.FC<DiffDisplayContainerProps> = ({
   if (data.length === 0) {
     return (
       <Box flexDirection="column">
-        <Text color="green">✨ No diff related to issue!</Text>
+        <Text color={theme.success}>✨ No diff related to issue!</Text>
       </Box>
     );
   }

--- a/src/components/HeaderDisplay.tsx
+++ b/src/components/HeaderDisplay.tsx
@@ -1,17 +1,41 @@
 import React from "react";
 import { Box, Text } from "ink";
-import { MAIN_COLOR } from "../theme/colors.js";
+import { getTheme } from "../theme/theme.js";
+import { useCompactChrome } from "../hooks/useTerminalSize.js";
 
-const HeaderDisplay: React.FC = () => (
-  <Box
-    key="static-header"
-    borderColor={MAIN_COLOR}
-    borderStyle="round"
-    flexDirection="column"
-  >
-    <Text>Baz Checkout</Text>
-    <Text>Review and approve your PRs with Baz's AI Code Review Agent</Text>
-  </Box>
-);
+const theme = getTheme();
+
+const TITLE = "Baz Checkout";
+const TAGLINE = "Review and approve your PRs with Baz's AI Code Review Agent";
+
+/**
+ * The banner drops to a single line in short windows, where the four rows of
+ * the bordered version cost more than they are worth.
+ */
+const HeaderDisplay: React.FC = () => {
+  const compact = useCompactChrome();
+
+  if (compact) {
+    return (
+      <Box key="static-header">
+        <Text color={theme.main} bold>
+          {TITLE}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      key="static-header"
+      borderColor={theme.main}
+      borderStyle="round"
+      flexDirection="column"
+    >
+      <Text>{TITLE}</Text>
+      <Text>{TAGLINE}</Text>
+    </Box>
+  );
+};
 
 export default HeaderDisplay;

--- a/src/components/MentionAutocomplete.tsx
+++ b/src/components/MentionAutocomplete.tsx
@@ -3,6 +3,9 @@ import { Box, Text, useInput } from "ink";
 import type { ChangeReviewer } from "../lib/providers/index.js";
 import { MentionableUser } from "../models/chat.js";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../theme/symbols.js";
+import { getTheme } from "../theme/theme.js";
+
+const theme = getTheme();
 
 interface MentionAutocompleteProps {
   reviewers: ChangeReviewer[];
@@ -63,11 +66,11 @@ const MentionAutocomplete: React.FC<MentionAutocompleteProps> = ({
       <Box
         flexDirection="column"
         borderStyle="round"
-        borderColor="yellow"
+        borderColor={theme.warning}
         paddingX={1}
         marginTop={1}
       >
-        <Text color="yellow">No reviewers match your search.</Text>
+        <Text color={theme.warning}>No reviewers match your search.</Text>
         <Text dimColor italic>
           ESC to cancel
         </Text>
@@ -100,9 +103,7 @@ const MentionAutocomplete: React.FC<MentionAutocompleteProps> = ({
                   ? ITEM_SELECTOR
                   : ITEM_SELECTION_GAP}
                 {reviewer.name}
-                {reviewer.login && (
-                  <Text color="gray"> (@{reviewer.login})</Text>
-                )}
+                {reviewer.login && <Text dimColor> (@{reviewer.login})</Text>}
               </Text>
             </Box>
           );

--- a/src/components/MentionAutocomplete.tsx
+++ b/src/components/MentionAutocomplete.tsx
@@ -4,6 +4,7 @@ import type { ChangeReviewer } from "../lib/providers/index.js";
 import { MentionableUser } from "../models/chat.js";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../theme/symbols.js";
 import { getTheme } from "../theme/theme.js";
+import { useTerminalSize } from "../hooks/useTerminalSize.js";
 
 const theme = getTheme();
 
@@ -21,6 +22,7 @@ const MentionAutocomplete: React.FC<MentionAutocompleteProps> = ({
   onCancel,
 }) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const { rows } = useTerminalSize();
 
   const filteredReviewers: MentionableUser[] = reviewers
     .filter((reviewer): reviewer is ChangeReviewer & { login: string } => {
@@ -78,7 +80,9 @@ const MentionAutocomplete: React.FC<MentionAutocompleteProps> = ({
     );
   }
 
-  const maxVisible = 10;
+  // The list shares the window with the input box and its hints, so it only
+  // grows to what the terminal can spare.
+  const maxVisible = Math.max(1, Math.min(10, rows - 8));
   const startIndex = Math.max(
     0,
     Math.min(selectedIndex - 5, filteredReviewers.length - maxVisible),
@@ -98,7 +102,9 @@ const MentionAutocomplete: React.FC<MentionAutocompleteProps> = ({
           const actualIndex = startIndex + index;
           return (
             <Box key={reviewer.id}>
-              <Text color={actualIndex === selectedIndex ? "cyan" : "white"}>
+              <Text
+                color={actualIndex === selectedIndex ? theme.main : undefined}
+              >
                 {actualIndex === selectedIndex
                   ? ITEM_SELECTOR
                   : ITEM_SELECTION_GAP}

--- a/src/components/PullRequestReview.tsx
+++ b/src/components/PullRequestReview.tsx
@@ -14,13 +14,15 @@ import ReviewMenu, {
 import TriggerSpecReviewPrompt from "../pages/SpecReview/TriggerSpecReviewPrompt.js";
 import MetRequirementBrowser from "../pages/SpecReview/MetRequirementBrowser.js";
 import PRWalkthrough from "../pages/PRWalkthrough/PRWalkthrough.js";
-import { MAIN_COLOR } from "../theme/colors.js";
+import { getTheme } from "../theme/theme.js";
 import { useAppMode } from "../lib/config/index.js";
 import type { Requirement } from "../lib/providers/index.js";
 import { PRContext } from "../lib/providers/index.js";
 import { useRepoWriteAccess } from "../hooks/useRepoWriteAccess.js";
 import PRChat from "../pages/PRChat/PRChat.js";
 import { IssueType } from "../models/chat.js";
+
+const theme = getTheme();
 
 interface MenuStateData {
   unmetRequirements: Requirement[];
@@ -75,10 +77,10 @@ const PullRequestReview: React.FC<PullRequestReviewProps> = ({
   if (loading) {
     return (
       <Box>
-        <Text color={MAIN_COLOR}>
+        <Text color={theme.main}>
           <Spinner type="dots" />
         </Text>
-        <Text color={MAIN_COLOR}> Fetching details...</Text>
+        <Text color={theme.main}> Fetching details...</Text>
       </Box>
     );
   }
@@ -87,7 +89,7 @@ const PullRequestReview: React.FC<PullRequestReviewProps> = ({
     return (
       <StateMessage
         message={`Error: ${error}`}
-        color="red"
+        color={theme.error}
         bold
         onComplete={onComplete}
         onBack={onBack}
@@ -365,7 +367,7 @@ const PullRequestReview: React.FC<PullRequestReviewProps> = ({
       return (
         <StateMessage
           message="Spec review is currently in progress. Continuing to review menu..."
-          color="yellow"
+          color={theme.warning}
           onComplete={handleSpecReviewInProgressContinue}
           onBack={onBack}
         />
@@ -452,7 +454,7 @@ const PullRequestReview: React.FC<PullRequestReviewProps> = ({
 
 const StateMessage: React.FC<{
   message: string;
-  color: string;
+  color?: string;
   bold?: boolean;
   onComplete: () => void;
   onBack: () => void;

--- a/src/components/ScrollableViewport.spec.tsx
+++ b/src/components/ScrollableViewport.spec.tsx
@@ -51,7 +51,13 @@ function createStdin() {
   return stream;
 }
 
-const Harness: React.FC = () => (
+interface HarnessProps {
+  /** Extra rows of chrome, standing in for an open mention list. */
+  footerRows?: number;
+  resetKey?: string | number;
+}
+
+const Harness: React.FC<HarnessProps> = ({ footerRows = 1, resetKey }) => (
   <ScreenLayoutProvider>
     <ReservedRows id="banner">
       <Box>
@@ -59,16 +65,16 @@ const Harness: React.FC = () => (
       </Box>
     </ReservedRows>
 
-    <ScrollableViewport>
+    <ScrollableViewport resetKey={resetKey}>
       {Array.from({ length: CONTENT_LINES }, (_, index) => (
         <Text key={index}>line {index}</Text>
       ))}
     </ScrollableViewport>
 
     <ReservedRows id="footer">
-      <Box>
-        <Text>FOOTER</Text>
-      </Box>
+      {Array.from({ length: footerRows }, (_, index) => (
+        <Text key={index}>{index === 0 ? "FOOTER" : `footer ${index}`}</Text>
+      ))}
     </ReservedRows>
   </ScreenLayoutProvider>
 );
@@ -78,10 +84,10 @@ async function settle() {
   await new Promise((resolve) => setTimeout(resolve, 60));
 }
 
-async function renderHarness(rows: number) {
+async function renderHarness(rows: number, props: HarnessProps = {}) {
   const stdout = createStdout(rows);
   const stdin = createStdin();
-  const instance = render(<Harness />, {
+  const instance = render(<Harness {...props} />, {
     stdout: stdout.stream as unknown as NodeJS.WriteStream,
     stdin: stdin as unknown as NodeJS.ReadStream,
     patchConsole: false,
@@ -94,6 +100,10 @@ async function renderHarness(rows: number) {
     frame: () => stdout.lastFrame().join("\n"),
     press: async (sequence: string) => {
       stdin.write(sequence);
+      await settle();
+    },
+    rerender: async (next: HarnessProps) => {
+      instance.rerender(<Harness {...next} />);
       await settle();
     },
     cleanup: () => instance.unmount(),
@@ -141,6 +151,30 @@ describe("ScrollableViewport", () => {
     expect(harness.frame()).toContain(`line ${CONTENT_LINES - 1}`);
     expect(harness.lines().length).toBeLessThanOrEqual(12);
     expect(harness.lines().at(-1)).toContain("FOOTER");
+
+    harness.cleanup();
+  });
+
+  it("never grows past the window, even when chrome fills it", async () => {
+    // 8 rows of footer chrome (an open mention list) in a 12-row window leaves
+    // the viewport nothing; it must collapse rather than push chrome off screen.
+    const harness = await renderHarness(12, { footerRows: 8 });
+
+    expect(harness.lines().length).toBeLessThanOrEqual(12);
+    expect(harness.lines()[0]).toContain("BANNER");
+    expect(harness.frame()).toContain("footer 7");
+
+    harness.cleanup();
+  });
+
+  it("returns to the top when the reviewed item changes", async () => {
+    const harness = await renderHarness(12, { resetKey: "first" });
+
+    await harness.press(PAGE_DOWN);
+    expect(harness.lines()).not.toContain("line 0");
+
+    await harness.rerender({ resetKey: "second" });
+    expect(harness.lines()).toContain("line 0");
 
     harness.cleanup();
   });

--- a/src/components/ScrollableViewport.spec.tsx
+++ b/src/components/ScrollableViewport.spec.tsx
@@ -157,7 +157,8 @@ describe("ScrollableViewport", () => {
 
   it("never grows past the window, even when chrome fills it", async () => {
     // 8 rows of footer chrome (an open mention list) in a 12-row window leaves
-    // the viewport nothing; it must collapse rather than push chrome off screen.
+    // no room for the viewport; it must collapse rather than push chrome off
+    // screen.
     const harness = await renderHarness(12, { footerRows: 8 });
 
     expect(harness.lines().length).toBeLessThanOrEqual(12);

--- a/src/components/ScrollableViewport.spec.tsx
+++ b/src/components/ScrollableViewport.spec.tsx
@@ -155,18 +155,36 @@ describe("ScrollableViewport", () => {
     harness.cleanup();
   });
 
-  it("never grows past the window, even when chrome fills it", async () => {
-    // 8 rows of footer chrome (an open mention list) in a 12-row window leaves
-    // no room for the viewport; it must collapse rather than push chrome off
-    // screen.
-    const harness = await renderHarness(12, { footerRows: 8 });
+  // In a 12-row window the banner takes 1 row and SLACK_ROWS takes another, so
+  // the rows left for the viewport and its status line are 10 - footerRows.
+  // These are the sizes where chrome crowds the viewport out entirely, e.g. an
+  // open mention list.
+  it.each([
+    { footerRows: 8, budget: 2 },
+    { footerRows: 9, budget: 1 },
+    { footerRows: 10, budget: 0 },
+    { footerRows: 11, budget: -1 },
+  ])(
+    "never grows past the window with $footerRows footer rows (budget $budget)",
+    async ({ footerRows, budget }) => {
+      const harness = await renderHarness(12, { footerRows });
 
-    expect(harness.lines().length).toBeLessThanOrEqual(12);
-    expect(harness.lines()[0]).toContain("BANNER");
-    expect(harness.frame()).toContain("footer 7");
+      // Chrome stays whole and the frame still fits the window.
+      expect(harness.lines().length).toBeLessThanOrEqual(12);
+      expect(harness.lines()[0]).toContain("BANNER");
+      expect(harness.frame()).toContain(`footer ${footerRows - 1}`);
 
-    harness.cleanup();
-  });
+      if (budget > 0) {
+        expect(harness.frame()).toContain("line 0");
+      } else {
+        // Nothing left to show: the viewport collapses instead of pushing the
+        // chrome off screen.
+        expect(harness.frame()).not.toContain("line 0");
+      }
+
+      harness.cleanup();
+    },
+  );
 
   it("returns to the top when the reviewed item changes", async () => {
     const harness = await renderHarness(12, { resetKey: "first" });

--- a/src/components/ScrollableViewport.spec.tsx
+++ b/src/components/ScrollableViewport.spec.tsx
@@ -1,0 +1,157 @@
+import React from "react";
+import { PassThrough, Writable } from "node:stream";
+import { Box, render, Text } from "ink";
+import { describe, expect, it } from "vitest";
+import ScrollableViewport from "./ScrollableViewport.js";
+import { ReservedRows, ScreenLayoutProvider } from "./layout/ScreenLayout.js";
+
+const CONTENT_LINES = 40;
+
+const ESC = "";
+const ANSI_PATTERN = new RegExp(`${ESC}\\[[0-9;?]*[A-Za-z]`, "g");
+const ARROW_UP = `${ESC}[A`;
+const ARROW_DOWN = `${ESC}[B`;
+const PAGE_DOWN = `${ESC}[6~`;
+
+function createStdout(rows: number, columns = 100) {
+  let output = "";
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      output += chunk.toString();
+      callback();
+    },
+  }) as Writable & { columns: number; rows: number; isTTY: boolean };
+  stream.columns = columns;
+  stream.rows = rows;
+  stream.isTTY = true;
+
+  return {
+    stream,
+    // Ink rewrites the whole frame on every render; the last one is what the
+    // user is looking at.
+    lastFrame: () => {
+      const frames = output.replace(ANSI_PATTERN, "").split("BANNER");
+      const last = frames[frames.length - 1];
+      return `BANNER${last}`
+        .split("\n")
+        .map((line) => line.trimEnd())
+        .filter((line) => line.trim().length > 0);
+    },
+  };
+}
+
+// Ink reads input through the "readable" event, so a real duplex stream is
+// the simplest fake stdin.
+function createStdin() {
+  const stream = new PassThrough() as PassThrough & Record<string, unknown>;
+  stream.isTTY = true;
+  stream.setRawMode = () => {};
+  stream.ref = () => {};
+  stream.unref = () => {};
+  return stream;
+}
+
+const Harness: React.FC = () => (
+  <ScreenLayoutProvider>
+    <ReservedRows id="banner">
+      <Box>
+        <Text>BANNER</Text>
+      </Box>
+    </ReservedRows>
+
+    <ScrollableViewport>
+      {Array.from({ length: CONTENT_LINES }, (_, index) => (
+        <Text key={index}>line {index}</Text>
+      ))}
+    </ScrollableViewport>
+
+    <ReservedRows id="footer">
+      <Box>
+        <Text>FOOTER</Text>
+      </Box>
+    </ReservedRows>
+  </ScreenLayoutProvider>
+);
+
+// Ink throttles its writes, so wait for the trailing frame.
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 60));
+}
+
+async function renderHarness(rows: number) {
+  const stdout = createStdout(rows);
+  const stdin = createStdin();
+  const instance = render(<Harness />, {
+    stdout: stdout.stream as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  await settle();
+
+  return {
+    lines: () => stdout.lastFrame(),
+    frame: () => stdout.lastFrame().join("\n"),
+    press: async (sequence: string) => {
+      stdin.write(sequence);
+      await settle();
+    },
+    cleanup: () => instance.unmount(),
+  };
+}
+
+describe("ScrollableViewport", () => {
+  it("keeps the reserved chrome on screen in a short window", async () => {
+    const harness = await renderHarness(12);
+
+    expect(harness.lines().length).toBeLessThanOrEqual(12);
+    expect(harness.lines()[0]).toContain("BANNER");
+    expect(harness.lines().at(-1)).toContain("FOOTER");
+    // Content is clipped, not dumped in full.
+    expect(harness.frame()).toContain("line 0");
+    expect(harness.frame()).not.toContain(`line ${CONTENT_LINES - 1}`);
+
+    harness.cleanup();
+  });
+
+  it("reports the visible range and scrolls with the arrow keys", async () => {
+    const harness = await renderHarness(12);
+    expect(harness.frame()).toContain(`of ${CONTENT_LINES}`);
+
+    await harness.press(ARROW_DOWN);
+    expect(harness.frame()).toContain("line 1");
+    expect(harness.lines()).not.toContain("line 0");
+
+    await harness.press(ARROW_UP);
+    expect(harness.lines()).toContain("line 0");
+
+    await harness.press(PAGE_DOWN);
+    expect(harness.lines()).not.toContain("line 0");
+
+    harness.cleanup();
+  });
+
+  it("stops scrolling at the end of the content", async () => {
+    const harness = await renderHarness(12);
+
+    for (let i = 0; i < 5; i++) {
+      await harness.press(PAGE_DOWN);
+    }
+
+    expect(harness.frame()).toContain(`line ${CONTENT_LINES - 1}`);
+    expect(harness.lines().length).toBeLessThanOrEqual(12);
+    expect(harness.lines().at(-1)).toContain("FOOTER");
+
+    harness.cleanup();
+  });
+
+  it("shows everything and no scroll hint when the window is tall", async () => {
+    const harness = await renderHarness(60);
+
+    expect(harness.frame()).toContain("line 0");
+    expect(harness.frame()).toContain(`line ${CONTENT_LINES - 1}`);
+    expect(harness.frame()).not.toContain("to scroll");
+
+    harness.cleanup();
+  });
+});

--- a/src/components/ScrollableViewport.tsx
+++ b/src/components/ScrollableViewport.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Box, DOMElement, measureElement, Text, useInput } from "ink";
+import { useTerminalSize } from "../hooks/useTerminalSize.js";
+import { useReservedRows } from "./layout/ScreenLayout.js";
+
+interface ScrollableViewportProps {
+  children: React.ReactNode;
+  /** Follow the bottom of the content as it grows (e.g. streaming chat). */
+  followContent?: boolean;
+  /** Ignore scroll keys while another component owns them. */
+  isActive?: boolean;
+  /**
+   * Rows to keep visible even in a window with almost no room left. Ink
+   * mismeasures a one-row viewport, so two is the floor.
+   */
+  minHeight?: number;
+}
+
+// One row for the scroll status line plus one so the terminal itself never
+// scrolls the frame away.
+const STATUS_ROWS = 1;
+const SLACK_ROWS = 1;
+
+/**
+ * Clips its children to the rows the terminal has left and lets the user
+ * scroll through them with the arrow keys.
+ *
+ * The available height is the terminal height minus the chrome registered
+ * through `ReservedRows` (banner, headers, chat input), so the input box and
+ * its hints stay visible however short the window is. Content is shifted with
+ * a negative margin and clipped by `overflow: hidden`.
+ */
+const ScrollableViewport: React.FC<ScrollableViewportProps> = ({
+  children,
+  followContent = false,
+  isActive = true,
+  minHeight = 2,
+}) => {
+  const contentRef = useRef<DOMElement | null>(null);
+  const { rows } = useTerminalSize();
+  const reservedRows = useReservedRows();
+
+  const [contentHeight, setContentHeight] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [pinnedToBottom, setPinnedToBottom] = useState(followContent);
+
+  const viewportHeight = Math.max(
+    minHeight,
+    rows - reservedRows - STATUS_ROWS - SLACK_ROWS,
+  );
+  const maxOffset = Math.max(0, contentHeight - viewportHeight);
+
+  // Re-measure after every render: content grows while a reply streams in.
+  useEffect(() => {
+    if (!contentRef.current) return;
+    const measured = measureElement(contentRef.current).height;
+    setContentHeight((previous) =>
+      previous === measured ? previous : measured,
+    );
+  });
+
+  // Following was just switched on (the first chat reply arrives): jump down.
+  const wasFollowing = useRef(followContent);
+  useEffect(() => {
+    if (followContent && !wasFollowing.current) setPinnedToBottom(true);
+    wasFollowing.current = followContent;
+  }, [followContent]);
+
+  // Keep the offset meaningful when the content or the window changes size.
+  useEffect(() => {
+    setOffset((previous) => {
+      if (followContent && pinnedToBottom) return maxOffset;
+      return Math.min(previous, maxOffset);
+    });
+  }, [followContent, pinnedToBottom, maxOffset]);
+
+  const scrollBy = useCallback(
+    (delta: number) => {
+      setOffset((previous) => {
+        const next = Math.max(0, Math.min(maxOffset, previous + delta));
+        setPinnedToBottom(next >= maxOffset);
+        return next;
+      });
+    },
+    [maxOffset],
+  );
+
+  useInput(
+    (input, key) => {
+      const page = Math.max(1, viewportHeight - 1);
+
+      if (key.upArrow) scrollBy(-1);
+      else if (key.downArrow) scrollBy(1);
+      else if (key.pageUp) scrollBy(-page);
+      else if (key.pageDown) scrollBy(page);
+      else if (key.ctrl && input === "u") scrollBy(-Math.ceil(page / 2));
+      else if (key.ctrl && input === "d") scrollBy(Math.ceil(page / 2));
+    },
+    { isActive: isActive && maxOffset > 0 },
+  );
+
+  const canScroll = maxOffset > 0;
+  const firstVisibleLine = contentHeight === 0 ? 0 : offset + 1;
+  const lastVisibleLine = Math.min(contentHeight, offset + viewportHeight);
+
+  return (
+    <>
+      <Box
+        flexDirection="column"
+        flexShrink={0}
+        height={viewportHeight}
+        overflow="hidden"
+      >
+        <Box
+          ref={contentRef}
+          flexDirection="column"
+          flexShrink={0}
+          marginTop={-offset}
+        >
+          {children}
+        </Box>
+      </Box>
+
+      {/* Always one row, so showing the hint can never change the layout. */}
+      <Box flexShrink={0}>
+        <Text dimColor>
+          {canScroll
+            ? `${offset > 0 ? "↑" : " "}${offset < maxOffset ? "↓" : " "} lines ${firstVisibleLine}-${lastVisibleLine} of ${contentHeight} · ↑/↓ PgUp/PgDn to scroll`
+            : " "}
+        </Text>
+      </Box>
+    </>
+  );
+};
+
+export default ScrollableViewport;

--- a/src/components/ScrollableViewport.tsx
+++ b/src/components/ScrollableViewport.tsx
@@ -10,16 +10,19 @@ interface ScrollableViewportProps {
   /** Ignore scroll keys while another component owns them. */
   isActive?: boolean;
   /**
-   * Rows to keep visible even in a window with almost no room left. Ink
-   * mismeasures a one-row viewport, so two is the floor.
+   * Scrolling starts from the top again whenever this changes - use the
+   * identity of the thing being reviewed, so moving to the next comment does
+   * not open partway down it.
    */
-  minHeight?: number;
+  resetKey?: string | number;
 }
 
 // One row for the scroll status line plus one so the terminal itself never
 // scrolls the frame away.
 const STATUS_ROWS = 1;
 const SLACK_ROWS = 1;
+// Below this the status line gives its row back to the content.
+const MIN_ROWS_FOR_STATUS = 3;
 
 /**
  * Clips its children to the rows the terminal has left and lets the user
@@ -34,7 +37,7 @@ const ScrollableViewport: React.FC<ScrollableViewportProps> = ({
   children,
   followContent = false,
   isActive = true,
-  minHeight = 2,
+  resetKey,
 }) => {
   const contentRef = useRef<DOMElement | null>(null);
   const { rows } = useTerminalSize();
@@ -44,10 +47,14 @@ const ScrollableViewport: React.FC<ScrollableViewportProps> = ({
   const [offset, setOffset] = useState(0);
   const [pinnedToBottom, setPinnedToBottom] = useState(followContent);
 
-  const viewportHeight = Math.max(
-    minHeight,
-    rows - reservedRows - STATUS_ROWS - SLACK_ROWS,
-  );
+  // Never claim rows the terminal does not have: overflowing the window is the
+  // very thing this component exists to prevent. If chrome alone fills the
+  // window the viewport collapses to nothing rather than pushing it off screen.
+  const budgetRows = Math.max(0, rows - reservedRows - SLACK_ROWS);
+  // With almost nothing to spare, content is worth more than the status line -
+  // and a one-row viewport is measured wrongly by Ink, which breaks scrolling.
+  const showStatus = budgetRows >= MIN_ROWS_FOR_STATUS;
+  const viewportHeight = showStatus ? budgetRows - STATUS_ROWS : budgetRows;
   const maxOffset = Math.max(0, contentHeight - viewportHeight);
 
   // Re-measure after every render: content grows while a reply streams in.
@@ -58,6 +65,13 @@ const ScrollableViewport: React.FC<ScrollableViewportProps> = ({
       previous === measured ? previous : measured,
     );
   });
+
+  // A different comment or requirement starts from the top, however far the
+  // user had scrolled through the previous one.
+  useEffect(() => {
+    setOffset(0);
+    setPinnedToBottom(false);
+  }, [resetKey]);
 
   // Following was just switched on (the first chat reply arrives): jump down.
   const wasFollowing = useRef(followContent);
@@ -121,14 +135,17 @@ const ScrollableViewport: React.FC<ScrollableViewportProps> = ({
         </Box>
       </Box>
 
-      {/* Always one row, so showing the hint can never change the layout. */}
-      <Box flexShrink={0}>
-        <Text dimColor>
-          {canScroll
-            ? `${offset > 0 ? "↑" : " "}${offset < maxOffset ? "↓" : " "} lines ${firstVisibleLine}-${lastVisibleLine} of ${contentHeight} · ↑/↓ PgUp/PgDn to scroll`
-            : " "}
-        </Text>
-      </Box>
+      {/* A fixed row whenever it is shown, so the hint appearing cannot
+          change the layout. */}
+      {showStatus && (
+        <Box flexShrink={0}>
+          <Text dimColor>
+            {canScroll
+              ? `${offset > 0 ? "↑" : " "}${offset < maxOffset ? "↓" : " "} lines ${firstVisibleLine}-${lastVisibleLine} of ${contentHeight} · ↑/↓ PgUp/PgDn to scroll`
+              : " "}
+          </Text>
+        </Box>
+      )}
     </>
   );
 };

--- a/src/components/SelectRenderers.tsx
+++ b/src/components/SelectRenderers.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Text } from "ink";
+import type { IndicatorProps, ItemProps } from "ink-select-input";
+import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../theme/symbols.js";
+import { getTheme } from "../theme/theme.js";
+
+const theme = getTheme();
+
+/**
+ * Themed renderers for `ink-select-input`, so every prompt in the CLI marks
+ * its selection the same way and colorless mode is decided in one place.
+ *
+ * Pass them straight through:
+ *   <SelectInput
+ *     indicatorComponent={SelectIndicator}
+ *     itemComponent={SelectItem}
+ *   />
+ *
+ * A prompt whose items need more than a label (see `ReviewMenu`) keeps its own
+ * `itemComponent` and still uses `SelectIndicator`.
+ */
+export const SelectIndicator: React.FC<IndicatorProps> = ({ isSelected }) => (
+  <Text color={isSelected ? theme.success : undefined} dimColor={!isSelected}>
+    {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
+  </Text>
+);
+
+export const SelectItem: React.FC<ItemProps> = ({ isSelected, label }) => (
+  <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
+);

--- a/src/components/layout/ScreenLayout.tsx
+++ b/src/components/layout/ScreenLayout.tsx
@@ -1,0 +1,98 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Box, DOMElement, measureElement } from "ink";
+
+interface ScreenLayoutValue {
+  /** Rows taken by chrome that must always stay on screen. */
+  reservedRows: number;
+  reserve: (id: string, rows: number) => void;
+  release: (id: string) => void;
+}
+
+const ScreenLayoutContext = createContext<ScreenLayoutValue>({
+  reservedRows: 0,
+  reserve: () => {},
+  release: () => {},
+});
+
+/**
+ * Tracks how many terminal rows are used by things that are never scrolled -
+ * the banner, the selected-PR line, the chat input - so a scrollable viewport
+ * can size itself to whatever is left.
+ */
+export const ScreenLayoutProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [rowsById, setRowsById] = useState<Record<string, number>>({});
+
+  const reserve = useCallback((id: string, rows: number) => {
+    setRowsById((previous) =>
+      previous[id] === rows ? previous : { ...previous, [id]: rows },
+    );
+  }, []);
+
+  const release = useCallback((id: string) => {
+    setRowsById((previous) => {
+      if (!(id in previous)) return previous;
+      return Object.fromEntries(
+        Object.entries(previous).filter(([key]) => key !== id),
+      );
+    });
+  }, []);
+
+  const reservedRows = useMemo(
+    () => Object.values(rowsById).reduce((total, rows) => total + rows, 0),
+    [rowsById],
+  );
+
+  const value = useMemo(
+    () => ({ reservedRows, reserve, release }),
+    [reservedRows, reserve, release],
+  );
+
+  return (
+    <ScreenLayoutContext.Provider value={value}>
+      {children}
+    </ScreenLayoutContext.Provider>
+  );
+};
+
+export function useReservedRows(): number {
+  return useContext(ScreenLayoutContext).reservedRows;
+}
+
+interface ReservedRowsProps {
+  /** Stable identifier for this piece of chrome. */
+  id: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Measures its children and reports their height as reserved. Wrap anything
+ * that sits outside a scrollable viewport but shares the same screen.
+ */
+export const ReservedRows: React.FC<ReservedRowsProps> = ({ id, children }) => {
+  const ref = useRef<DOMElement | null>(null);
+  const { reserve, release } = useContext(ScreenLayoutContext);
+
+  // Height changes as the content does (the input grows when help is shown).
+  useEffect(() => {
+    if (!ref.current) return;
+    reserve(id, measureElement(ref.current).height);
+  });
+
+  useEffect(() => () => release(id), [id, release]);
+
+  return (
+    <Box ref={ref} flexDirection="column" flexShrink={0}>
+      {children}
+    </Box>
+  );
+};

--- a/src/flows/Integration/IntegrationPrompt.tsx
+++ b/src/flows/Integration/IntegrationPrompt.tsx
@@ -2,6 +2,9 @@ import React, { useState } from "react";
 import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface IntegrationPromptProps {
   onSelect: (shouldIntegrate: boolean) => void;
@@ -33,7 +36,7 @@ const IntegrationPrompt: React.FC<IntegrationPromptProps> = ({ onSelect }) => {
     <Box flexDirection="column">
       <Box marginBottom={1} flexDirection="column">
         <Box marginBottom={1}>
-          <Text bold color="yellow">
+          <Text bold color={theme.warning}>
             ⚠️ Integration Required
           </Text>
         </Box>
@@ -48,7 +51,7 @@ const IntegrationPrompt: React.FC<IntegrationPromptProps> = ({ onSelect }) => {
         </Text>
       </Box>
       <Box marginBottom={1}>
-        <Text bold color="cyan">
+        <Text bold color={theme.main}>
           Would you like to set it up now?
         </Text>
       </Box>
@@ -56,12 +59,15 @@ const IntegrationPrompt: React.FC<IntegrationPromptProps> = ({ onSelect }) => {
         items={items}
         onSelect={handleSelect}
         indicatorComponent={({ isSelected }) => (
-          <Text color={isSelected ? "green" : "gray"}>
+          <Text
+            color={isSelected ? theme.success : undefined}
+            dimColor={!isSelected}
+          >
             {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
           </Text>
         )}
         itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
         )}
       />
       <Box marginTop={1}>

--- a/src/flows/Integration/IntegrationPrompt.tsx
+++ b/src/flows/Integration/IntegrationPrompt.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from "react";
 import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
-import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import { getTheme } from "../../theme/theme.js";
+import {
+  SelectIndicator,
+  SelectItem,
+} from "../../components/SelectRenderers.js";
 
 const theme = getTheme();
 
@@ -58,17 +61,8 @@ const IntegrationPrompt: React.FC<IntegrationPromptProps> = ({ onSelect }) => {
       <SelectInput
         items={items}
         onSelect={handleSelect}
-        indicatorComponent={({ isSelected }) => (
-          <Text
-            color={isSelected ? theme.success : undefined}
-            dimColor={!isSelected}
-          >
-            {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
-          </Text>
-        )}
-        itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
-        )}
+        indicatorComponent={SelectIndicator}
+        itemComponent={SelectItem}
       />
       <Box marginTop={1}>
         <Text dimColor italic>

--- a/src/flows/Integration/IntegrationProviderSelector.tsx
+++ b/src/flows/Integration/IntegrationProviderSelector.tsx
@@ -3,6 +3,9 @@ import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import { IntegrationProvider } from "../../integrations/types.js";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface IntegrationProviderSelectorProps {
   providers: IntegrationProvider[];
@@ -52,7 +55,7 @@ const IntegrationProviderSelector: React.FC<
     return (
       <Box flexDirection="column">
         <Box marginBottom={1}>
-          <Text color="yellow">ℹ️ {notImplementedMessage}</Text>
+          <Text color={theme.warning}>ℹ️ {notImplementedMessage}</Text>
         </Box>
         <Box>
           <Text dimColor italic>
@@ -66,7 +69,7 @@ const IntegrationProviderSelector: React.FC<
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
-        <Text bold color="cyan">
+        <Text bold color={theme.main}>
           🔧 Select an integration provider:
         </Text>
       </Box>
@@ -74,12 +77,15 @@ const IntegrationProviderSelector: React.FC<
         items={items}
         onSelect={handleSelect}
         indicatorComponent={({ isSelected }) => (
-          <Text color={isSelected ? "green" : "gray"}>
+          <Text
+            color={isSelected ? theme.success : undefined}
+            dimColor={!isSelected}
+          >
             {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
           </Text>
         )}
         itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
         )}
       />
       <Box marginTop={1}>

--- a/src/flows/Integration/IntegrationProviderSelector.tsx
+++ b/src/flows/Integration/IntegrationProviderSelector.tsx
@@ -2,8 +2,11 @@ import React, { useState } from "react";
 import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import { IntegrationProvider } from "../../integrations/types.js";
-import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import { getTheme } from "../../theme/theme.js";
+import {
+  SelectIndicator,
+  SelectItem,
+} from "../../components/SelectRenderers.js";
 
 const theme = getTheme();
 
@@ -76,17 +79,8 @@ const IntegrationProviderSelector: React.FC<
       <SelectInput
         items={items}
         onSelect={handleSelect}
-        indicatorComponent={({ isSelected }) => (
-          <Text
-            color={isSelected ? theme.success : undefined}
-            dimColor={!isSelected}
-          >
-            {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
-          </Text>
-        )}
-        itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
-        )}
+        indicatorComponent={SelectIndicator}
+        itemComponent={SelectItem}
       />
       <Box marginTop={1}>
         <Text dimColor italic>

--- a/src/flows/Review/PostReviewPrompt.tsx
+++ b/src/flows/Review/PostReviewPrompt.tsx
@@ -8,6 +8,9 @@ import LoadingSpinner from "../../components/LoadingSpinner.js";
 import { PRContext } from "../../lib/providers/index.js";
 import { useAppMode } from "../../lib/config/AppModeContext.js";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 export type PostReviewAction =
   | "approve"
@@ -151,10 +154,10 @@ const PostReviewPrompt: React.FC<PostReviewPromptProps> = ({
       <Box marginBottom={1}>
         {actionError && (
           <Box marginBottom={1}>
-            <Text color="red">✗ {actionError}</Text>
+            <Text color={theme.error}>✗ {actionError}</Text>
           </Box>
         )}
-        <Text bold color="cyan">
+        <Text bold color={theme.main}>
           What would you like to do next?
         </Text>
       </Box>
@@ -162,12 +165,15 @@ const PostReviewPrompt: React.FC<PostReviewPromptProps> = ({
         items={items}
         onSelect={handleSelect}
         indicatorComponent={({ isSelected }) => (
-          <Text color={isSelected ? "green" : "gray"}>
+          <Text
+            color={isSelected ? theme.success : undefined}
+            dimColor={!isSelected}
+          >
             {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
           </Text>
         )}
         itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
         )}
       />
       <Box marginTop={1}>

--- a/src/flows/Review/PostReviewPrompt.tsx
+++ b/src/flows/Review/PostReviewPrompt.tsx
@@ -7,8 +7,11 @@ import { useFetchMergeStatus } from "../../hooks/useFetchMergeStatus.js";
 import LoadingSpinner from "../../components/LoadingSpinner.js";
 import { PRContext } from "../../lib/providers/index.js";
 import { useAppMode } from "../../lib/config/AppModeContext.js";
-import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import { getTheme } from "../../theme/theme.js";
+import {
+  SelectIndicator,
+  SelectItem,
+} from "../../components/SelectRenderers.js";
 
 const theme = getTheme();
 
@@ -164,17 +167,8 @@ const PostReviewPrompt: React.FC<PostReviewPromptProps> = ({
       <SelectInput
         items={items}
         onSelect={handleSelect}
-        indicatorComponent={({ isSelected }) => (
-          <Text
-            color={isSelected ? theme.success : undefined}
-            dimColor={!isSelected}
-          >
-            {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
-          </Text>
-        )}
-        itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
-        )}
+        indicatorComponent={SelectIndicator}
+        itemComponent={SelectItem}
       />
       <Box marginTop={1}>
         <Text dimColor italic>

--- a/src/flows/Review/Review.tsx
+++ b/src/flows/Review/Review.tsx
@@ -12,19 +12,28 @@ import LocalDiffPrompt, {
 } from "../LocalReview/LocalDiffPrompt.js";
 import LocalPullRequestReview from "../LocalReview/LocalPullRequestReview.js";
 import { getRepoName } from "../../lib/git.js";
-import { MAIN_COLOR } from "../../theme/colors.js";
+import { getTheme } from "../../theme/theme.js";
 import { REVIEW_COMPLETE_TEXT } from "../../theme/banners.js";
 import { useAppMode } from "../../lib/config/index.js";
+import {
+  ReservedRows,
+  ScreenLayoutProvider,
+} from "../../components/layout/ScreenLayout.js";
+
+const theme = getTheme();
 
 const SelectedPRHeader: React.FC<{ pullRequest: PullRequest }> = ({
   pullRequest,
 }) => (
-  <Box marginBottom={1}>
-    <Text color="green">✓ Selected PR: </Text>
-    <Text color="yellow">
-      #{pullRequest.prNumber} {pullRequest.title} [{pullRequest.repositoryName}]
-    </Text>
-  </Box>
+  <ReservedRows id="selected-pr">
+    <Box marginBottom={1}>
+      <Text color={theme.success}>✓ Selected PR: </Text>
+      <Text color={theme.accent}>
+        #{pullRequest.prNumber} {pullRequest.title} [
+        {pullRequest.repositoryName}]
+      </Text>
+    </Box>
+  </ReservedRows>
 );
 
 type FlowState =
@@ -276,8 +285,8 @@ const InternalReviewFlow: React.FC<InternalReviewFlowProps> = ({ isLocal }) => {
       return (
         <Box flexDirection="column">
           <Box marginBottom={1}>
-            <Text color="green">✓ Reviewing {reviewLabel} </Text>
-            <Text color="yellow">[{getRepoName()}]</Text>
+            <Text color={theme.success}>✓ Reviewing {reviewLabel} </Text>
+            <Text color={theme.accent}>[{getRepoName()}]</Text>
           </Box>
           <LocalPullRequestReview
             diffText={diffResult.diffText}
@@ -295,14 +304,14 @@ const InternalReviewFlow: React.FC<InternalReviewFlowProps> = ({ isLocal }) => {
       return (
         <Box flexDirection="column">
           <Box flexDirection="column" marginBottom={1}>
-            <Text color={MAIN_COLOR}>{REVIEW_COMPLETE_TEXT}</Text>
+            <Text color={theme.main}>{REVIEW_COMPLETE_TEXT}</Text>
             <Text>Local review completed</Text>
           </Box>
         </Box>
       );
 
     default:
-      return <Text color="red">Unknown step</Text>;
+      return <Text color={theme.error}>Unknown step</Text>;
   }
 };
 
@@ -317,7 +326,7 @@ const CompleteMessage: React.FC<{
     <Box flexDirection="column">
       <SelectedPRHeader pullRequest={flowState.selectedPR} />
       <Box flexDirection="column" marginBottom={1}>
-        <Text color={MAIN_COLOR}>{REVIEW_COMPLETE_TEXT}</Text>
+        <Text color={theme.main}>{REVIEW_COMPLETE_TEXT}</Text>
         <Text>PR Review completed</Text>
       </Box>
       {onSelect && (
@@ -339,10 +348,12 @@ interface ReviewFlowProps {
 }
 
 const ReviewFlow: React.FC<ReviewFlowProps> = ({ isLocal }) => (
-  <>
-    <HeaderDisplay />
+  <ScreenLayoutProvider>
+    <ReservedRows id="banner">
+      <HeaderDisplay />
+    </ReservedRows>
 
     <InternalReviewFlow isLocal={isLocal} />
-  </>
+  </ScreenLayoutProvider>
 );
 export default ReviewFlow;

--- a/src/flows/Review/ReviewMenu.tsx
+++ b/src/flows/Review/ReviewMenu.tsx
@@ -2,9 +2,9 @@ import React, { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import { MAIN_COLOR } from "../../theme/colors.js";
-import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import LineInput from "../../components/LineInput.js";
 import { getTheme } from "../../theme/theme.js";
+import { SelectIndicator } from "../../components/SelectRenderers.js";
 
 const theme = getTheme();
 
@@ -224,14 +224,7 @@ const ReviewMenu: React.FC<ReviewMenuProps> = ({
         isFocused={menuOwnsKeys}
         onSelect={handleSelect}
         onHighlight={handleHighlight}
-        indicatorComponent={({ isSelected: isHighlighted }) => (
-          <Text
-            color={isHighlighted ? theme.success : undefined}
-            dimColor={!isHighlighted}
-          >
-            {isHighlighted ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
-          </Text>
-        )}
+        indicatorComponent={SelectIndicator}
         itemComponent={({ isSelected: isHighlighted, label }) => {
           const completed = completionByLabel.get(label) ?? false;
 

--- a/src/flows/Review/ReviewMenu.tsx
+++ b/src/flows/Review/ReviewMenu.tsx
@@ -4,6 +4,9 @@ import SelectInput from "ink-select-input";
 import { MAIN_COLOR } from "../../theme/colors.js";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import LineInput from "../../components/LineInput.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 const CHAT_ITEM_LABEL = "Chat with PR";
 
@@ -222,7 +225,10 @@ const ReviewMenu: React.FC<ReviewMenuProps> = ({
         onSelect={handleSelect}
         onHighlight={handleHighlight}
         indicatorComponent={({ isSelected: isHighlighted }) => (
-          <Text color={isHighlighted ? "green" : "gray"}>
+          <Text
+            color={isHighlighted ? theme.success : undefined}
+            dimColor={!isHighlighted}
+          >
             {isHighlighted ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
           </Text>
         )}
@@ -249,13 +255,15 @@ const ReviewMenu: React.FC<ReviewMenuProps> = ({
               <Text
                 strikethrough
                 dimColor={!isHighlighted}
-                color={isHighlighted ? "cyan" : undefined}
+                color={isHighlighted ? theme.main : undefined}
               >
                 {label}
               </Text>
             );
           }
-          return <Text color={isHighlighted ? "cyan" : "white"}>{label}</Text>;
+          return (
+            <Text color={isHighlighted ? theme.main : theme.text}>{label}</Text>
+          );
         }}
       />
 

--- a/src/hooks/useTerminalSize.ts
+++ b/src/hooks/useTerminalSize.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { useStdout } from "ink";
+
+export interface TerminalSize {
+  columns: number;
+  rows: number;
+}
+
+const DEFAULT_SIZE: TerminalSize = { columns: 80, rows: 24 };
+
+/** Terminal dimensions, kept in sync with window resizes. */
+export function useTerminalSize(): TerminalSize {
+  const { stdout } = useStdout();
+  const [size, setSize] = useState<TerminalSize>(() => ({
+    columns: stdout?.columns ?? DEFAULT_SIZE.columns,
+    rows: stdout?.rows ?? DEFAULT_SIZE.rows,
+  }));
+
+  useEffect(() => {
+    if (!stdout) return;
+
+    const onResize = () => {
+      setSize((previous) => {
+        const columns = stdout.columns ?? DEFAULT_SIZE.columns;
+        const rows = stdout.rows ?? DEFAULT_SIZE.rows;
+        if (previous.columns === columns && previous.rows === rows) {
+          return previous;
+        }
+        return { columns, rows };
+      });
+    };
+
+    onResize();
+    stdout.on("resize", onResize);
+    return () => {
+      stdout.off("resize", onResize);
+    };
+  }, [stdout]);
+
+  return size;
+}
+
+/** Rows below which the UI trims its chrome to leave room for content. */
+export const COMPACT_ROWS = 24;
+
+/** True when the window is too short for the roomy banner and hint block. */
+export function useCompactChrome(threshold = COMPACT_ROWS): boolean {
+  return useTerminalSize().rows < threshold;
+}

--- a/src/pages/IssueBrowser.tsx
+++ b/src/pages/IssueBrowser.tsx
@@ -286,27 +286,33 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
     }
   }, []);
 
-  return (
-    <Box flexDirection="column">
+  // The comment and its diff scroll together with the conversation, so a short
+  // window still shows the input box and the hints.
+  const issueHeader = (
+    <Box flexDirection="column" flexShrink={0}>
       <ExplainComponent issue={currentIssue} />
 
       <DisplayComponent issue={currentIssue} context={context} />
+    </Box>
+  );
 
-      <Box marginTop={1}>
-        <ChatDisplay
-          messages={chatMessages}
-          isLoading={isLoading}
-          onSubmit={handleSubmit}
-          availableCommands={availableCommands}
-          prId={prId}
-          fullRepoName={fullRepoName}
-          prNumber={prNumber}
-          enableMentions={currentIssue.type === "discussion"}
-          onBack={onBack}
-          onInterrupt={handleInterrupt}
-          isResponseActive={isResponseActive}
-        />
-      </Box>
+  return (
+    <Box flexDirection="column" flexGrow={1} flexShrink={1} minHeight={0}>
+      <ChatDisplay
+        header={issueHeader}
+        scrollable
+        messages={chatMessages}
+        isLoading={isLoading}
+        onSubmit={handleSubmit}
+        availableCommands={availableCommands}
+        prId={prId}
+        fullRepoName={fullRepoName}
+        prNumber={prNumber}
+        enableMentions={currentIssue.type === "discussion"}
+        onBack={onBack}
+        onInterrupt={handleInterrupt}
+        isResponseActive={isResponseActive}
+      />
     </Box>
   );
 };

--- a/src/pages/IssueBrowser.tsx
+++ b/src/pages/IssueBrowser.tsx
@@ -301,6 +301,7 @@ const IssueBrowser: React.FC<IssueBrowserProps> = ({
       <ChatDisplay
         header={issueHeader}
         scrollable
+        scrollResetKey={currentIssue.data.id}
         messages={chatMessages}
         isLoading={isLoading}
         onSubmit={handleSubmit}

--- a/src/pages/PRChat/PRChat.tsx
+++ b/src/pages/PRChat/PRChat.tsx
@@ -243,8 +243,8 @@ const PRChat: React.FC<PRChatProps> = ({
     abortControllerRef.current = null;
   }, []);
 
-  return (
-    <Box flexDirection="column">
+  const chatHeader = (
+    <Box flexDirection="column" flexShrink={0}>
       <Box marginBottom={1}>
         <Text color={MAIN_COLOR} bold>
           {chatTitle ?? "PR Chat"}
@@ -257,8 +257,14 @@ const PRChat: React.FC<PRChatProps> = ({
             "Chat about the pull request with Baz. Press ESC to go back."}
         </Text>
       </Box>
+    </Box>
+  );
 
+  return (
+    <Box flexDirection="column">
       <ChatDisplay
+        header={chatHeader}
+        scrollable
         messages={chatMessages}
         isLoading={isLoading}
         onSubmit={handleChatSubmit}

--- a/src/pages/PROverview/PullRequestOverview.tsx
+++ b/src/pages/PROverview/PullRequestOverview.tsx
@@ -7,6 +7,9 @@ import type {
   SpecReview,
 } from "../../lib/providers/index.js";
 import { Issue } from "../../issues/types.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 const CHECKBOX_PLACEHOLDER = " □ ";
 
@@ -68,9 +71,9 @@ const LinesSummary: React.FC<{
   return (
     <Text>
       <Text>{CHECKBOX_PLACEHOLDER}</Text>
-      <Text color="green">+{pr.lines_added} lines added</Text>
+      <Text color={theme.success}>+{pr.lines_added} lines added</Text>
       <Text> / </Text>
-      <Text color="red">-{pr.lines_deleted} lines removed</Text>
+      <Text color={theme.error}>-{pr.lines_deleted} lines removed</Text>
     </Text>
   );
 };

--- a/src/pages/PRSelector/MergeConfirmationPrompt.tsx
+++ b/src/pages/PRSelector/MergeConfirmationPrompt.tsx
@@ -6,6 +6,9 @@ import type { PullRequest, PRContext } from "../../lib/providers/index.js";
 import { useAppMode } from "../../lib/config/AppModeContext.js";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import { MAIN_COLOR } from "../../theme/colors.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface MergeConfirmationPromptProps {
   pr: PullRequest;
@@ -78,7 +81,7 @@ const MergeConfirmationPrompt: React.FC<MergeConfirmationPromptProps> = ({
     return (
       <Box flexDirection="column">
         <Box marginBottom={1}>
-          <Text bold color="yellow">
+          <Text bold color={theme.warning}>
             Merge {pr.title}?
           </Text>
         </Box>
@@ -86,12 +89,15 @@ const MergeConfirmationPrompt: React.FC<MergeConfirmationPromptProps> = ({
           items={items}
           onSelect={handleConfirm}
           indicatorComponent={({ isSelected }) => (
-            <Text color={isSelected ? "green" : "gray"}>
+            <Text
+              color={isSelected ? theme.success : undefined}
+              dimColor={!isSelected}
+            >
               {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
             </Text>
           )}
           itemComponent={({ isSelected, label }) => (
-            <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+            <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
           )}
         />
         <Box marginTop={1}>
@@ -117,7 +123,7 @@ const MergeConfirmationPrompt: React.FC<MergeConfirmationPromptProps> = ({
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
-        <Text color="red" bold>
+        <Text color={theme.error} bold>
           ✗ Failed to merge PR: {error}
         </Text>
       </Box>

--- a/src/pages/PRSelector/MergeConfirmationPrompt.tsx
+++ b/src/pages/PRSelector/MergeConfirmationPrompt.tsx
@@ -4,9 +4,12 @@ import SelectInput from "ink-select-input";
 import Spinner from "ink-spinner";
 import type { PullRequest, PRContext } from "../../lib/providers/index.js";
 import { useAppMode } from "../../lib/config/AppModeContext.js";
-import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import { MAIN_COLOR } from "../../theme/colors.js";
 import { getTheme } from "../../theme/theme.js";
+import {
+  SelectIndicator,
+  SelectItem,
+} from "../../components/SelectRenderers.js";
 
 const theme = getTheme();
 
@@ -88,17 +91,8 @@ const MergeConfirmationPrompt: React.FC<MergeConfirmationPromptProps> = ({
         <SelectInput
           items={items}
           onSelect={handleConfirm}
-          indicatorComponent={({ isSelected }) => (
-            <Text
-              color={isSelected ? theme.success : undefined}
-              dimColor={!isSelected}
-            >
-              {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
-            </Text>
-          )}
-          itemComponent={({ isSelected, label }) => (
-            <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
-          )}
+          indicatorComponent={SelectIndicator}
+          itemComponent={SelectItem}
         />
         <Box marginTop={1}>
           <Text dimColor italic>

--- a/src/pages/PRSelector/PullRequestCard.tsx
+++ b/src/pages/PRSelector/PullRequestCard.tsx
@@ -6,8 +6,10 @@ import type {
   CodeChangeReview,
 } from "../../lib/providers/index.js";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
-import { MAIN_COLOR } from "../../theme/colors.js";
 import { isBazReviewer } from "../../lib/reviewer.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface PullRequestCardProps {
   pr: PullRequest;
@@ -45,17 +47,17 @@ function getCIIcon(status: CIStatus):
   | {
       text: string;
       icon: string;
-      color: string;
+      color?: string;
     }
   | undefined {
   if (status === "success") {
-    return { text: "passed", icon: "✓", color: "green" };
+    return { text: "passed", icon: "✓", color: theme.success };
   }
   if (status === "pending") {
-    return { text: "pending", icon: "●", color: "yellow" };
+    return { text: "pending", icon: "●", color: theme.warning };
   }
   if (status === "failure") {
-    return { text: "failed", icon: "✗", color: "red" };
+    return { text: "failed", icon: "✗", color: theme.error };
   }
   return undefined;
 }
@@ -112,31 +114,31 @@ function getReviewStatus(
 
 function getReviewStatusDisplay(status: ReviewStatus): {
   text: string;
-  color: string;
+  color?: string;
 } {
   switch (status) {
     case "waiting_review":
-      return { text: "● Awaiting review", color: "black" };
+      return { text: "● Awaiting review", color: theme.text };
     case "reviewed":
-      return { text: "◐ Reviewed", color: "yellow" };
+      return { text: "◐ Reviewed", color: theme.warning };
     case "reviewed_by_me":
-      return { text: "◐ Reviewed by me", color: "yellow" };
+      return { text: "◐ Reviewed by me", color: theme.warning };
     case "approved":
-      return { text: "✓ Approved", color: "green" };
+      return { text: "✓ Approved", color: theme.success };
     case "approved_by_me":
-      return { text: "✓ Approved by me", color: "green" };
+      return { text: "✓ Approved by me", color: theme.success };
   }
 }
 
 function getBazBadge(status: "approved" | "reviewed" | "none"): {
   text: string;
-  color: string;
+  color?: string;
 } | null {
   switch (status) {
     case "approved":
-      return { text: "[✓ baz]", color: "cyan" };
+      return { text: "[✓ baz]", color: theme.main };
     case "reviewed":
-      return { text: "[◐ baz]", color: "yellow" };
+      return { text: "[◐ baz]", color: theme.warning };
     case "none":
       return null;
   }
@@ -156,15 +158,15 @@ export const PullRequestCard: React.FC<PullRequestCardProps> = ({
   const bazBadge = getBazBadge(bazStatus);
   const updatedTime = pr.updatedAt;
 
-  const titleColor = isSelected ? "cyan" : "white";
-  const metadataColor = isSelected ? MAIN_COLOR : "white";
+  const titleColor = isSelected ? theme.main : theme.text;
+  const metadataColor = isSelected ? theme.main : theme.text;
 
   return (
     <Box flexDirection="column">
       <Box>
         <Text bold={isSelected} color={titleColor}>
           {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}#{pr.prNumber}{" "}
-          {pr.title} <Text color="gray">[{pr.repositoryName}]</Text>{" "}
+          {pr.title} <Text dimColor>[{pr.repositoryName}]</Text>{" "}
           {ciIcon?.icon && (
             <Text bold color={ciIcon.color}>
               {ciIcon.icon}
@@ -191,7 +193,7 @@ export const PullRequestCard: React.FC<PullRequestCardProps> = ({
         {ciIcon?.text && <Text> • CI {ciIcon.text}</Text>}
       </Text>
       {canMerge && (
-        <Text bold color="green">
+        <Text bold color={theme.success}>
           {"    "}Want to merge? Ctrl+G and let's go!
         </Text>
       )}

--- a/src/pages/PRSelector/PullRequestSelector.tsx
+++ b/src/pages/PRSelector/PullRequestSelector.tsx
@@ -7,6 +7,9 @@ import { useFetchUser } from "../../hooks/useFetchUser.js";
 import MergeConfirmationPrompt from "./MergeConfirmationPrompt.js";
 import LineInput from "../../components/LineInput.js";
 import { isCtrlChord, type EditorAction } from "../../lib/input/line-editor.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface PullRequestSearchKeywords {
   author?: string;
@@ -171,14 +174,14 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
-        <Text bold color="cyan">
+        <Text bold color={theme.main}>
           🔍 Search for a Pull Request:
         </Text>
       </Box>
 
       <Box flexDirection="column" marginBottom={1}>
         <Box>
-          <Text color="gray">Search: </Text>
+          <Text dimColor>Search: </Text>
           <LineInput
             value={searchQuery}
             onChange={setSearchQuery}
@@ -197,14 +200,16 @@ const PullRequestSelector: React.FC<PullRequestSelectorProps> = ({
 
       <Box flexDirection="column" marginTop={1}>
         {filteredPRs.length === 0 ? (
-          <Text color="yellow">No pull requests match your search.</Text>
+          <Text color={theme.warning}>No pull requests match your search.</Text>
         ) : (
           <>
             {hasLocal && (
               <Box marginBottom={1}>
                 <Text
                   color={
-                    selectedIndex === LOCAL_CHANGES_INDEX ? "cyan" : "gray"
+                    selectedIndex === LOCAL_CHANGES_INDEX
+                      ? theme.main
+                      : undefined
                   }
                   bold={selectedIndex === LOCAL_CHANGES_INDEX}
                 >

--- a/src/pages/PRSelector/PullRequestSelectorContainer.tsx
+++ b/src/pages/PRSelector/PullRequestSelectorContainer.tsx
@@ -5,6 +5,9 @@ import type { PullRequest } from "../../lib/providers/index.js";
 import { usePullRequests } from "../../hooks/usePullRequests.js";
 import { getDiff, isOnNonDefaultBranch } from "../../lib/git.js";
 import PullRequestSelector from "./PullRequestSelector.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface PullRequestSelectorContainerProps {
   onSelect: (pr: PullRequest) => void;
@@ -34,10 +37,10 @@ const PullRequestSelectorContainer: React.FC<
   if (loading) {
     return (
       <Box>
-        <Text color="blue">
+        <Text color={theme.info}>
           <Spinner type="dots" />
         </Text>
-        <Text color="blue"> Fetching pull requests...</Text>
+        <Text color={theme.info}> Fetching pull requests...</Text>
       </Box>
     );
   }
@@ -45,7 +48,7 @@ const PullRequestSelectorContainer: React.FC<
   if (error) {
     return (
       <Box flexDirection="column">
-        <Text color="red" bold>
+        <Text color={theme.error} bold>
           ❌ Error: {error}
         </Text>
       </Box>
@@ -77,7 +80,7 @@ const EmptyPRState: React.FC<{ onBack?: () => void }> = ({ onBack }) => {
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
-        <Text color="yellow">📭 No open pull requests found</Text>
+        <Text color={theme.warning}>📭 No open pull requests found</Text>
       </Box>
       <Box>
         <Text dimColor italic>

--- a/src/pages/PRWalkthrough/UpdateAvailablePrompt.tsx
+++ b/src/pages/PRWalkthrough/UpdateAvailablePrompt.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
-import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import { getTheme } from "../../theme/theme.js";
+import {
+  SelectIndicator,
+  SelectItem,
+} from "../../components/SelectRenderers.js";
 
 const theme = getTheme();
 
@@ -40,17 +43,8 @@ const UpdateAvailablePrompt: React.FC<UpdateAvailablePromptProps> = ({
       <SelectInput
         items={items}
         onSelect={handleSelect}
-        indicatorComponent={({ isSelected }) => (
-          <Text
-            color={isSelected ? theme.success : undefined}
-            dimColor={!isSelected}
-          >
-            {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
-          </Text>
-        )}
-        itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
-        )}
+        indicatorComponent={SelectIndicator}
+        itemComponent={SelectItem}
       />
       <Box marginTop={1}>
         <Text dimColor italic>

--- a/src/pages/PRWalkthrough/UpdateAvailablePrompt.tsx
+++ b/src/pages/PRWalkthrough/UpdateAvailablePrompt.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 type UserChoice = "continue" | "startNew";
 
@@ -29,7 +32,7 @@ const UpdateAvailablePrompt: React.FC<UpdateAvailablePromptProps> = ({
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
-        <Text bold color="cyan">
+        <Text bold color={theme.main}>
           The pull request has been updated since your last review. How would
           you like to proceed?
         </Text>
@@ -38,12 +41,15 @@ const UpdateAvailablePrompt: React.FC<UpdateAvailablePromptProps> = ({
         items={items}
         onSelect={handleSelect}
         indicatorComponent={({ isSelected }) => (
-          <Text color={isSelected ? "green" : "gray"}>
+          <Text
+            color={isSelected ? theme.success : undefined}
+            dimColor={!isSelected}
+          >
             {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
           </Text>
         )}
         itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
         )}
       />
       <Box marginTop={1}>

--- a/src/pages/SpecReview/MetRequirementBrowser.tsx
+++ b/src/pages/SpecReview/MetRequirementBrowser.tsx
@@ -6,6 +6,9 @@ import ChatDisplay from "../chat/ChatDisplay.js";
 import { ChatMessage, IssueType } from "../../models/chat.js";
 import { IssueCommand } from "../../issues/types.js";
 import { processStream, StreamAbortError } from "../../lib/chat-stream.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface MetRequirementBrowserProps {
   metRequirements: Requirement[];
@@ -232,7 +235,7 @@ const MetRequirementBrowser: React.FC<MetRequirementBrowserProps> = ({
 
       <Box marginBottom={1} flexDirection="column">
         <Text bold>Verdict:</Text>
-        <Text color="green">{currentRequirement.verdict}</Text>
+        <Text color={theme.success}>{currentRequirement.verdict}</Text>
         {currentRequirement.verdict_explanation && (
           <Text dimColor>{currentRequirement.verdict_explanation}</Text>
         )}
@@ -253,6 +256,7 @@ const MetRequirementBrowser: React.FC<MetRequirementBrowserProps> = ({
         <ChatDisplay
           header={requirementHeader}
           scrollable
+          scrollResetKey={currentRequirement.id}
           messages={chatMessages}
           isLoading={isLoading}
           onSubmit={handleSubmit}

--- a/src/pages/SpecReview/MetRequirementBrowser.tsx
+++ b/src/pages/SpecReview/MetRequirementBrowser.tsx
@@ -210,8 +210,8 @@ const MetRequirementBrowser: React.FC<MetRequirementBrowserProps> = ({
     },
   ];
 
-  return (
-    <Box flexDirection="column">
+  const requirementHeader = (
+    <Box flexDirection="column" flexShrink={0}>
       <Box marginBottom={1}>
         <Text color={MAIN_COLOR} bold>
           Met requirement ({currentIndex + 1}/{metRequirements.length})
@@ -244,9 +244,15 @@ const MetRequirementBrowser: React.FC<MetRequirementBrowserProps> = ({
           <Text>{currentRequirement.evidence}</Text>
         </Box>
       )}
+    </Box>
+  );
 
-      <Box marginTop={1}>
+  return (
+    <Box flexDirection="column">
+      <Box marginTop={1} flexDirection="column">
         <ChatDisplay
+          header={requirementHeader}
+          scrollable
           messages={chatMessages}
           isLoading={isLoading}
           onSubmit={handleSubmit}

--- a/src/pages/SpecReview/ReviewStatusPrompt.tsx
+++ b/src/pages/SpecReview/ReviewStatusPrompt.tsx
@@ -2,8 +2,11 @@ import React, { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import { MAIN_COLOR } from "../../theme/colors.js";
-import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import { getTheme } from "../../theme/theme.js";
+import {
+  SelectIndicator,
+  SelectItem,
+} from "../../components/SelectRenderers.js";
 
 const theme = getTheme();
 
@@ -119,17 +122,8 @@ const ReviewStatusPrompt: React.FC<ReviewStatusPromptProps> = ({
       <SelectInput
         items={items}
         onSelect={handleSelect}
-        indicatorComponent={({ isSelected }) => (
-          <Text
-            color={isSelected ? theme.success : undefined}
-            dimColor={!isSelected}
-          >
-            {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
-          </Text>
-        )}
-        itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
-        )}
+        indicatorComponent={SelectIndicator}
+        itemComponent={SelectItem}
       />
 
       <Box marginTop={1}>

--- a/src/pages/SpecReview/ReviewStatusPrompt.tsx
+++ b/src/pages/SpecReview/ReviewStatusPrompt.tsx
@@ -3,6 +3,9 @@ import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import { MAIN_COLOR } from "../../theme/colors.js";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 export type ReviewStatusAction =
   | "viewMetRequirements"
@@ -108,7 +111,7 @@ const ReviewStatusPrompt: React.FC<ReviewStatusPromptProps> = ({
       </Box>
 
       <Box marginBottom={1}>
-        <Text bold color="cyan">
+        <Text bold color={theme.main}>
           What would you like to do next?
         </Text>
       </Box>
@@ -117,12 +120,15 @@ const ReviewStatusPrompt: React.FC<ReviewStatusPromptProps> = ({
         items={items}
         onSelect={handleSelect}
         indicatorComponent={({ isSelected }) => (
-          <Text color={isSelected ? "green" : "gray"}>
+          <Text
+            color={isSelected ? theme.success : undefined}
+            dimColor={!isSelected}
+          >
             {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
           </Text>
         )}
         itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
         )}
       />
 

--- a/src/pages/SpecReview/SpecReviewBrowser.tsx
+++ b/src/pages/SpecReview/SpecReviewBrowser.tsx
@@ -7,6 +7,9 @@ import ChatDisplay from "../chat/ChatDisplay.js";
 import { ChatMessage, IssueType } from "../../models/chat.js";
 import { IssueCommand } from "../../issues/types.js";
 import { processStream, StreamAbortError } from "../../lib/chat-stream.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface SpecReviewBrowserProps {
   unmetRequirements: Requirement[];
@@ -235,7 +238,7 @@ const SpecReviewBrowser: React.FC<SpecReviewBrowserProps> = ({
 
       <Box marginBottom={1} flexDirection="column">
         <Text bold>Verdict:</Text>
-        <Text color="red">{currentRequirement.verdict}</Text>
+        <Text color={theme.error}>{currentRequirement.verdict}</Text>
         {currentRequirement.verdict_explanation && (
           <Text>{renderMarkdown(currentRequirement.verdict_explanation)}</Text>
         )}
@@ -256,6 +259,7 @@ const SpecReviewBrowser: React.FC<SpecReviewBrowserProps> = ({
         <ChatDisplay
           header={requirementHeader}
           scrollable
+          scrollResetKey={currentRequirement.id}
           messages={chatMessages}
           isLoading={isLoading}
           onSubmit={handleSubmit}

--- a/src/pages/SpecReview/SpecReviewBrowser.tsx
+++ b/src/pages/SpecReview/SpecReviewBrowser.tsx
@@ -213,8 +213,8 @@ const SpecReviewBrowser: React.FC<SpecReviewBrowserProps> = ({
     },
   ];
 
-  return (
-    <Box flexDirection="column">
+  const requirementHeader = (
+    <Box flexDirection="column" flexShrink={0}>
       <Box marginBottom={1}>
         <Text color={MAIN_COLOR} bold>
           Unmet requirement ({currentIndex + 1}/{unmetRequirements.length})
@@ -247,9 +247,15 @@ const SpecReviewBrowser: React.FC<SpecReviewBrowserProps> = ({
           <Text>{currentRequirement.evidence}</Text>
         </Box>
       )}
+    </Box>
+  );
 
-      <Box marginTop={1}>
+  return (
+    <Box flexDirection="column">
+      <Box marginTop={1} flexDirection="column">
         <ChatDisplay
+          header={requirementHeader}
+          scrollable
           messages={chatMessages}
           isLoading={isLoading}
           onSubmit={handleSubmit}

--- a/src/pages/SpecReview/SpecReviewErrorPrompt.tsx
+++ b/src/pages/SpecReview/SpecReviewErrorPrompt.tsx
@@ -3,6 +3,9 @@ import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import { AxiosError } from "axios";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface ErrorPromptProps {
   error: unknown;
@@ -64,25 +67,28 @@ const ErrorPrompt: React.FC<ErrorPromptProps> = ({
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
-        <Text color="red" bold>
+        <Text color={theme.error} bold>
           ✗ Error{context ? `: ${context}` : ""}
         </Text>
       </Box>
 
       <Box marginBottom={1}>
-        <Text color="red">{errorMessage}</Text>
+        <Text color={theme.error}>{errorMessage}</Text>
       </Box>
 
       <SelectInput
         items={items}
         onSelect={handleSelect}
         indicatorComponent={({ isSelected }) => (
-          <Text color={isSelected ? "green" : "gray"}>
+          <Text
+            color={isSelected ? theme.success : undefined}
+            dimColor={!isSelected}
+          >
             {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
           </Text>
         )}
         itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
         )}
       />
 

--- a/src/pages/SpecReview/SpecReviewErrorPrompt.tsx
+++ b/src/pages/SpecReview/SpecReviewErrorPrompt.tsx
@@ -2,8 +2,11 @@ import React, { useState } from "react";
 import { Box, Text } from "ink";
 import SelectInput from "ink-select-input";
 import { AxiosError } from "axios";
-import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import { getTheme } from "../../theme/theme.js";
+import {
+  SelectIndicator,
+  SelectItem,
+} from "../../components/SelectRenderers.js";
 
 const theme = getTheme();
 
@@ -79,17 +82,8 @@ const ErrorPrompt: React.FC<ErrorPromptProps> = ({
       <SelectInput
         items={items}
         onSelect={handleSelect}
-        indicatorComponent={({ isSelected }) => (
-          <Text
-            color={isSelected ? theme.success : undefined}
-            dimColor={!isSelected}
-          >
-            {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
-          </Text>
-        )}
-        itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
-        )}
+        indicatorComponent={SelectIndicator}
+        itemComponent={SelectItem}
       />
 
       <Box marginTop={1}>

--- a/src/pages/SpecReview/TriggerSpecReviewPrompt.tsx
+++ b/src/pages/SpecReview/TriggerSpecReviewPrompt.tsx
@@ -5,8 +5,11 @@ import Spinner from "ink-spinner";
 import { triggerSpecReview } from "../../lib/clients/baz.js";
 import { MAIN_COLOR } from "../../theme/colors.js";
 import ErrorPrompt from "./SpecReviewErrorPrompt.js";
-import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
 import { getTheme } from "../../theme/theme.js";
+import {
+  SelectIndicator,
+  SelectItem,
+} from "../../components/SelectRenderers.js";
 
 const theme = getTheme();
 
@@ -122,17 +125,8 @@ const TriggerSpecReviewPrompt: React.FC<TriggerSpecReviewPromptProps> = ({
       <SelectInput
         items={items}
         onSelect={handleSelect}
-        indicatorComponent={({ isSelected }) => (
-          <Text
-            color={isSelected ? theme.success : undefined}
-            dimColor={!isSelected}
-          >
-            {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
-          </Text>
-        )}
-        itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
-        )}
+        indicatorComponent={SelectIndicator}
+        itemComponent={SelectItem}
       />
 
       <Box marginTop={1}>

--- a/src/pages/SpecReview/TriggerSpecReviewPrompt.tsx
+++ b/src/pages/SpecReview/TriggerSpecReviewPrompt.tsx
@@ -6,6 +6,9 @@ import { triggerSpecReview } from "../../lib/clients/baz.js";
 import { MAIN_COLOR } from "../../theme/colors.js";
 import ErrorPrompt from "./SpecReviewErrorPrompt.js";
 import { ITEM_SELECTION_GAP, ITEM_SELECTOR } from "../../theme/symbols.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface TriggerSpecReviewPromptProps {
   prId: string;
@@ -88,7 +91,7 @@ const TriggerSpecReviewPrompt: React.FC<TriggerSpecReviewPromptProps> = ({
   if (state.step === "triggered") {
     return (
       <Box marginBottom={1}>
-        <Text color="green">✓ Spec review triggered successfully</Text>
+        <Text color={theme.success}>✓ Spec review triggered successfully</Text>
       </Box>
     );
   }
@@ -107,11 +110,11 @@ const TriggerSpecReviewPrompt: React.FC<TriggerSpecReviewPromptProps> = ({
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
-        <Text color="yellow">No spec reviews found for this PR</Text>
+        <Text color={theme.warning}>No spec reviews found for this PR</Text>
       </Box>
 
       <Box marginBottom={1}>
-        <Text bold color="cyan">
+        <Text bold color={theme.main}>
           Would you like to trigger a spec review?
         </Text>
       </Box>
@@ -120,12 +123,15 @@ const TriggerSpecReviewPrompt: React.FC<TriggerSpecReviewPromptProps> = ({
         items={items}
         onSelect={handleSelect}
         indicatorComponent={({ isSelected }) => (
-          <Text color={isSelected ? "green" : "gray"}>
+          <Text
+            color={isSelected ? theme.success : undefined}
+            dimColor={!isSelected}
+          >
             {isSelected ? ITEM_SELECTOR : ITEM_SELECTION_GAP}
           </Text>
         )}
         itemComponent={({ isSelected, label }) => (
-          <Text color={isSelected ? "cyan" : "white"}>{label}</Text>
+          <Text color={isSelected ? theme.main : theme.text}>{label}</Text>
         )}
       />
 

--- a/src/pages/chat/ChatDisplay.tsx
+++ b/src/pages/chat/ChatDisplay.tsx
@@ -145,6 +145,11 @@ interface ChatDisplayProps {
    * scrollable, keeping the input pinned to the bottom of the window.
    */
   scrollable?: boolean;
+  /**
+   * Identity of what is being discussed. Scrolling restarts from the top when
+   * it changes, so the next comment does not open partway down.
+   */
+  scrollResetKey?: string | number;
 }
 
 const ChatDisplay = memo<ChatDisplayProps>(
@@ -164,10 +169,14 @@ const ChatDisplay = memo<ChatDisplayProps>(
     isResponseActive = false,
     header,
     scrollable = false,
+    scrollResetKey,
   }) => {
     const { stdout } = useStdout();
     const [terminalWidth, setTerminalWidth] = useState(stdout?.columns ?? 80);
     const [toolsExpanded, setToolsExpanded] = useState(false);
+    // The mention list takes over Up/Down while it is open; the viewport must
+    // not scroll behind it.
+    const [composerOwnsArrows, setComposerOwnsArrows] = useState(false);
 
     useEffect(() => {
       if (!stdout) return;
@@ -254,7 +263,11 @@ const ChatDisplay = memo<ChatDisplayProps>(
         minHeight={0}
       >
         {scrollable ? (
-          <ScrollableViewport followContent={messages.length > 0}>
+          <ScrollableViewport
+            followContent={messages.length > 0}
+            isActive={!composerOwnsArrows}
+            resetKey={scrollResetKey}
+          >
             {scrollableContent}
           </ScrollableViewport>
         ) : (
@@ -277,6 +290,7 @@ const ChatDisplay = memo<ChatDisplayProps>(
               onToggleToolCallExpansion={toggleTools}
               onInterrupt={onInterrupt}
               isResponseActive={isResponseActive}
+              onNavigationCaptureChange={setComposerOwnsArrows}
             />
           </InputChrome>
         )}

--- a/src/pages/chat/ChatDisplay.tsx
+++ b/src/pages/chat/ChatDisplay.tsx
@@ -5,23 +5,28 @@ import { ChatMessage } from "../../models/chat.js";
 import { IssueCommand } from "../../issues/types.js";
 import { renderMarkdown } from "../../lib/markdown.js";
 import ChatInput from "./ChatInput.js";
+import ScrollableViewport from "../../components/ScrollableViewport.js";
+import { ReservedRows } from "../../components/layout/ScreenLayout.js";
+import { getTheme } from "../../theme/theme.js";
 import ToolCallDisplay from "./ToolCallDisplay.js";
+
+const theme = getTheme();
 
 const MessageAuthor = memo(({ role }: { role: ChatMessage["role"] }) => {
   if (role === "user")
     return (
-      <Text bold color="cyan">
+      <Text bold color={theme.info}>
         You:
       </Text>
     );
   if (role === "assistant")
     return (
-      <Text bold color="yellow">
+      <Text bold color={theme.accent}>
         Baz:
       </Text>
     );
   return (
-    <Text bold color="red">
+    <Text bold color={theme.error}>
       Error:
     </Text>
   );
@@ -100,6 +105,22 @@ const MessageRow = memo(
   },
 );
 
+/**
+ * The input box must stay on screen, so its height counts against the
+ * scrollable area when the conversation is scrollable.
+ */
+const InputChrome: React.FC<{
+  reserve: boolean;
+  children: React.ReactNode;
+}> = ({ reserve, children }) =>
+  reserve ? (
+    <ReservedRows id="chat-input">{children}</ReservedRows>
+  ) : (
+    <Box flexDirection="column" flexShrink={0}>
+      {children}
+    </Box>
+  );
+
 interface ChatDisplayProps {
   messages: ChatMessage[];
   isLoading: boolean;
@@ -114,6 +135,16 @@ interface ChatDisplayProps {
   onBack: () => void;
   onInterrupt?: () => void;
   isResponseActive?: boolean;
+  /**
+   * Rendered above the messages, inside the scrollable area (e.g. the comment
+   * being reviewed and its diff).
+   */
+  header?: React.ReactNode;
+  /**
+   * Clip the header and messages to the terminal height and make them
+   * scrollable, keeping the input pinned to the bottom of the window.
+   */
+  scrollable?: boolean;
 }
 
 const ChatDisplay = memo<ChatDisplayProps>(
@@ -131,6 +162,8 @@ const ChatDisplay = memo<ChatDisplayProps>(
     onBack,
     onInterrupt,
     isResponseActive = false,
+    header,
+    scrollable = false,
   }) => {
     const { stdout } = useStdout();
     const [terminalWidth, setTerminalWidth] = useState(stdout?.columns ?? 80);
@@ -181,8 +214,10 @@ const ChatDisplay = memo<ChatDisplayProps>(
       { isActive: isLoading || hasPendingToolCalls },
     );
 
-    return (
-      <Box flexDirection="column">
+    const scrollableContent = (
+      <>
+        {header}
+
         <Box flexDirection="column">
           {messages.map((msg, i) => (
             <MessageRow
@@ -197,7 +232,7 @@ const ChatDisplay = memo<ChatDisplayProps>(
         {(isLoading || hasPendingToolCalls) && (
           <Box flexDirection="column" marginBottom={1}>
             <Box>
-              <Text color="magenta">
+              <Text color={theme.info}>
                 <Spinner type="dots" /> Thinking...
               </Text>
             </Box>
@@ -208,23 +243,42 @@ const ChatDisplay = memo<ChatDisplayProps>(
             )}
           </Box>
         )}
+      </>
+    );
+
+    return (
+      <Box
+        flexDirection="column"
+        flexGrow={scrollable ? 1 : 0}
+        flexShrink={1}
+        minHeight={0}
+      >
+        {scrollable ? (
+          <ScrollableViewport followContent={messages.length > 0}>
+            {scrollableContent}
+          </ScrollableViewport>
+        ) : (
+          scrollableContent
+        )}
 
         {!disabled && !isLoading && !hasPendingToolCalls && (
-          <ChatInput
-            onSubmit={handleSubmit}
-            placeholder={placeholder}
-            availableCommands={availableCommands}
-            enableMentions={enableMentions}
-            prId={prId}
-            fullRepoName={fullRepoName}
-            prNumber={prNumber}
-            onBack={onBack}
-            terminalWidth={terminalWidth}
-            toolsExist={activeToolCalls.length > 0}
-            onToggleToolCallExpansion={toggleTools}
-            onInterrupt={onInterrupt}
-            isResponseActive={isResponseActive}
-          />
+          <InputChrome reserve={scrollable}>
+            <ChatInput
+              onSubmit={handleSubmit}
+              placeholder={placeholder}
+              availableCommands={availableCommands}
+              enableMentions={enableMentions}
+              prId={prId}
+              fullRepoName={fullRepoName}
+              prNumber={prNumber}
+              onBack={onBack}
+              terminalWidth={terminalWidth}
+              toolsExist={activeToolCalls.length > 0}
+              onToggleToolCallExpansion={toggleTools}
+              onInterrupt={onInterrupt}
+              isResponseActive={isResponseActive}
+            />
+          </InputChrome>
         )}
       </Box>
     );

--- a/src/pages/chat/ChatInput.tsx
+++ b/src/pages/chat/ChatInput.tsx
@@ -19,6 +19,10 @@ import {
   parseKeySequence,
   snapToCharBoundary,
 } from "../../lib/input/line-editor.js";
+import { useCompactChrome } from "../../hooks/useTerminalSize.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface ChatInputProps {
   onSubmit: (message: string) => void;
@@ -58,6 +62,9 @@ const ChatInput = memo<ChatInputProps>((props) => {
 
   const appMode = useAppMode();
   const dataProvider = appMode.mode.dataProvider;
+  // In a short window the hints collapse onto one line so the conversation
+  // keeps the rows instead.
+  const compact = useCompactChrome();
 
   const visibleWidth = Math.max(10, terminalWidth - 6);
 
@@ -367,7 +374,7 @@ const ChatInput = memo<ChatInputProps>((props) => {
     <Box flexDirection="column">
       <Box
         borderStyle="round"
-        borderColor="cyan"
+        borderColor={theme.main}
         paddingX={1}
         width={terminalWidth}
         flexShrink={1}
@@ -385,9 +392,11 @@ const ChatInput = memo<ChatInputProps>((props) => {
       )}
 
       {!mention.show && (
-        <Box marginTop={1}>
+        <Box marginTop={compact ? 0 : 1}>
           <Text dimColor>
-            {showFullHelp ? commandHints.join("\n") : defaultHints.join("\n")}
+            {showFullHelp
+              ? commandHints.join(compact ? " · " : "\n")
+              : defaultHints.join(compact ? " · " : "\n")}
           </Text>
         </Box>
       )}

--- a/src/pages/chat/ChatInput.tsx
+++ b/src/pages/chat/ChatInput.tsx
@@ -38,6 +38,11 @@ interface ChatInputProps {
   terminalWidth: number;
   onInterrupt?: () => void;
   isResponseActive?: boolean;
+  /**
+   * Called when the composer takes over the arrow keys (the mention list is
+   * open), so the surrounding view can stop scrolling on them.
+   */
+  onNavigationCaptureChange?: (captured: boolean) => void;
 }
 
 // Throttle updates ~60fps
@@ -58,6 +63,7 @@ const ChatInput = memo<ChatInputProps>((props) => {
     terminalWidth,
     onInterrupt,
     isResponseActive = false,
+    onNavigationCaptureChange,
   } = props;
 
   const appMode = useAppMode();
@@ -111,6 +117,14 @@ const ChatInput = memo<ChatInputProps>((props) => {
       if (mentionTimeoutRef.current) clearTimeout(mentionTimeoutRef.current);
     };
   }, []);
+
+  // While the mention list is open it owns Up/Down, so tell the surrounding
+  // view to leave those keys alone.
+  const mentionOwnsArrows =
+    enableMentions && mention.show && reviewers.length > 0;
+  useEffect(() => {
+    onNavigationCaptureChange?.(mentionOwnsArrows);
+  }, [mentionOwnsArrows, onNavigationCaptureChange]);
 
   const checkMention = useCallback(() => {
     if (!enableMentions) return;
@@ -382,7 +396,7 @@ const ChatInput = memo<ChatInputProps>((props) => {
         {renderInput}
       </Box>
 
-      {enableMentions && mention.show && reviewers.length > 0 && (
+      {mentionOwnsArrows && (
         <MentionAutocomplete
           reviewers={reviewers}
           searchQuery={mention.query}

--- a/src/pages/chat/ToolCallDisplay.tsx
+++ b/src/pages/chat/ToolCallDisplay.tsx
@@ -4,6 +4,9 @@ import Spinner from "ink-spinner";
 import { ChatToolCall } from "../../models/chat.js";
 import { renderMarkdown } from "../../lib/markdown.js";
 import { MAIN_COLOR } from "../../theme/colors.js";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 const MIN_LOADER_TIME_MS = 3000;
 
@@ -52,20 +55,20 @@ const ToolCallDisplay = memo<ToolCallDisplayProps>(
         <Box>
           {showLoader ? (
             <>
-              <Text color="magenta">
+              <Text color={theme.info}>
                 <Spinner type="arrow3" />
               </Text>
-              <Text color="cyan" bold>
+              <Text color={theme.main} bold>
                 {formattedToolName}
               </Text>
-              {message && <Text color="gray"> ({message})</Text>}
+              {message && <Text dimColor> ({message})</Text>}
             </>
           ) : (
             <>
-              <Text color="cyan" bold>
+              <Text color={theme.main} bold>
                 🔧 {formattedToolName}
               </Text>
-              {message && <Text color="gray"> ({message})</Text>}
+              {message && <Text dimColor> ({message})</Text>}
               {!isExpanded && showExpandHint && (
                 <Text dimColor italic>
                   {" "}
@@ -82,7 +85,7 @@ const ToolCallDisplay = memo<ToolCallDisplayProps>(
             marginTop={1}
             paddingLeft={2}
             borderStyle="single"
-            borderColor="gray"
+            borderColor={theme.lineNumber.color}
           >
             <Box paddingLeft={1}>
               <Text>{renderedResult}</Text>

--- a/src/pages/chat/ToolCallDisplay.tsx
+++ b/src/pages/chat/ToolCallDisplay.tsx
@@ -3,7 +3,6 @@ import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
 import { ChatToolCall } from "../../models/chat.js";
 import { renderMarkdown } from "../../lib/markdown.js";
-import { MAIN_COLOR } from "../../theme/colors.js";
 import { getTheme } from "../../theme/theme.js";
 
 const theme = getTheme();
@@ -50,7 +49,7 @@ const ToolCallDisplay = memo<ToolCallDisplayProps>(
         marginY={1}
         paddingLeft={1}
         borderStyle="single"
-        borderColor={isExpanded ? MAIN_COLOR : "gray"}
+        borderColor={isExpanded ? theme.main : theme.lineNumber.color}
       >
         <Box>
           {showLoader ? (

--- a/src/pages/integrations/CredentialsFlow.tsx
+++ b/src/pages/integrations/CredentialsFlow.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import { Box, Text } from "ink";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface CredentialsFlowProps {
   providerName: string;
@@ -10,7 +13,7 @@ const CredentialsFlow: React.FC<CredentialsFlowProps> = ({ providerName }) => {
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
-        <Text color="yellow" bold>
+        <Text color={theme.warning} bold>
           ℹ️ Credentials Flow Not Yet Implemented
         </Text>
       </Box>

--- a/src/pages/integrations/OAuthFlow.tsx
+++ b/src/pages/integrations/OAuthFlow.tsx
@@ -4,6 +4,9 @@ import Spinner from "ink-spinner";
 import type { IntegrationType } from "../../lib/providers/index.js";
 import { fetchIntegrations } from "../../lib/clients/baz.js";
 import open from "open";
+import { getTheme } from "../../theme/theme.js";
+
+const theme = getTheme();
 
 interface OAuthFlowProps {
   providerName: string;
@@ -84,7 +87,7 @@ const OAuthFlow: React.FC<OAuthFlowProps> = ({
       return (
         <Box flexDirection="column">
           <Box>
-            <Text color="cyan">
+            <Text color={theme.main}>
               <Spinner type="dots" />
             </Text>
             <Text> Opening browser for {providerName} authentication...</Text>
@@ -96,10 +99,10 @@ const OAuthFlow: React.FC<OAuthFlowProps> = ({
       return (
         <Box flexDirection="column">
           <Box marginBottom={1}>
-            <Text color="green">✓ Browser opened</Text>
+            <Text color={theme.success}>✓ Browser opened</Text>
           </Box>
           <Box>
-            <Text color="cyan">
+            <Text color={theme.main}>
               <Spinner type="dots" />
             </Text>
             <Text> Waiting for {providerName} integration to complete...</Text>
@@ -115,7 +118,7 @@ const OAuthFlow: React.FC<OAuthFlowProps> = ({
     case "success":
       return (
         <Box flexDirection="column">
-          <Text color="green" bold>
+          <Text color={theme.success} bold>
             ✓ {providerName} integration successful!
           </Text>
         </Box>
@@ -124,10 +127,10 @@ const OAuthFlow: React.FC<OAuthFlowProps> = ({
     case "error":
       return (
         <Box flexDirection="column">
-          <Text color="red" bold>
+          <Text color={theme.error} bold>
             ✗ Integration failed
           </Text>
-          <Text color="red">{status.message}</Text>
+          <Text color={theme.error}>{status.message}</Text>
           <Box marginTop={1}>
             <Text dimColor italic>
               Press Ctrl+C to exit

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,6 +1,17 @@
-export const MAIN_COLOR = "#5656c4";
-export const TABLE_HEADER_COLOR = "#D3D3D3";
+import { getTheme } from "./theme.js";
 
-export const DIFF_ADDED_LINE_COLOR = "#9AFF9A";
-export const DIFF_DELETED_LINE_COLOR = "#FF82AB";
-export const DIFF_SELECTED_LINE_COLOR = "#FFF59D";
+/**
+ * Theme-derived color constants.
+ *
+ * These resolve from the active theme (see `theme.ts`), so they follow the
+ * terminal background and any user customization. `undefined` means "use the
+ * terminal's own color", which is what colorless mode produces.
+ */
+const theme = getTheme();
+
+export const MAIN_COLOR = theme.main;
+export const TABLE_HEADER_COLOR = theme.fileHeaderBg;
+
+export const DIFF_ADDED_LINE_COLOR = theme.diffAddedBg;
+export const DIFF_DELETED_LINE_COLOR = theme.diffDeletedBg;
+export const DIFF_SELECTED_LINE_COLOR = theme.diffSelectedBg;

--- a/src/theme/theme.spec.ts
+++ b/src/theme/theme.spec.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { detectTerminalBackground, resolveTheme } from "./theme.js";
+
+describe("detectTerminalBackground", () => {
+  it("honors an explicit override", () => {
+    expect(detectTerminalBackground({ BAZ_TERMINAL_BACKGROUND: "light" })).toBe(
+      "light",
+    );
+  });
+
+  it("reads COLORFGBG", () => {
+    expect(detectTerminalBackground({ COLORFGBG: "15;0" })).toBe("dark");
+    expect(detectTerminalBackground({ COLORFGBG: "0;15" })).toBe("light");
+    expect(detectTerminalBackground({ COLORFGBG: "15;default" })).toBe("dark");
+  });
+
+  it("defaults to dark", () => {
+    expect(detectTerminalBackground({})).toBe("dark");
+  });
+});
+
+describe("resolveTheme", () => {
+  const noFile = { BAZ_THEME_FILE: "/nonexistent/baz-theme.json" };
+
+  it("adapts to a dark terminal", () => {
+    const theme = resolveTheme({ ...noFile, COLORFGBG: "15;0" });
+    expect(theme.name).toBe("dark");
+    // Text color is always set alongside a background.
+    expect(theme.diffAdded.backgroundColor).toBeTruthy();
+    expect(theme.diffAdded.color).toBeTruthy();
+    expect(theme.diffSelected.color).toBeTruthy();
+  });
+
+  it("adapts to a light terminal", () => {
+    const theme = resolveTheme({ ...noFile, COLORFGBG: "0;15" });
+    expect(theme.name).toBe("light");
+    expect(theme.main).toBe("#5656c4");
+  });
+
+  it("can be forced", () => {
+    expect(resolveTheme({ ...noFile, BAZ_THEME: "light" }).name).toBe("light");
+    expect(
+      resolveTheme({ ...noFile, BAZ_THEME: "dark", COLORFGBG: "0;15" }).name,
+    ).toBe("dark");
+  });
+
+  it("turns colors off for BAZ_THEME=none and NO_COLOR", () => {
+    for (const environment of [
+      { ...noFile, BAZ_THEME: "none" },
+      { ...noFile, BAZ_THEME: "off" },
+      { ...noFile, NO_COLOR: "1" },
+      { ...noFile, TERM: "dumb" },
+    ]) {
+      const theme = resolveTheme(environment);
+      expect(theme.name).toBe("none");
+      expect(theme.colorsEnabled).toBe(false);
+      expect(theme.main).toBeUndefined();
+      expect(theme.diffAdded).toEqual({});
+      // Commented-on lines stay distinguishable without color.
+      expect(theme.diffSelected.bold).toBe(true);
+    }
+  });
+
+  it("applies per-color overrides from the environment", () => {
+    const theme = resolveTheme({
+      ...noFile,
+      BAZ_COLOR_DIFF_ADDED_BG: "#003300",
+      BAZ_COLOR_MAIN: "none",
+    });
+    expect(theme.diffAdded.backgroundColor).toBe("#003300");
+    expect(theme.main).toBeUndefined();
+  });
+
+  it("reads a theme file", () => {
+    const file = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "baz-theme-")),
+      "theme.json",
+    );
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ theme: "light", diffAddedBg: "#abcdef" }),
+    );
+
+    const theme = resolveTheme({ BAZ_THEME_FILE: file });
+    expect(theme.name).toBe("light");
+    expect(theme.diffAdded.backgroundColor).toBe("#abcdef");
+  });
+
+  it("ignores a broken theme file", () => {
+    const file = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "baz-theme-")),
+      "theme.json",
+    );
+    fs.writeFileSync(file, "{not json");
+
+    expect(() => resolveTheme({ BAZ_THEME_FILE: file })).not.toThrow();
+  });
+
+  it("overrides win over a forced theme, colors stay on", () => {
+    const theme = resolveTheme({
+      ...noFile,
+      BAZ_THEME: "none",
+      BAZ_COLOR_DIFF_SELECTED_BG: "#222200",
+    });
+    expect(theme.colorsEnabled).toBe(true);
+    expect(theme.diffSelected.backgroundColor).toBe("#222200");
+  });
+});

--- a/src/theme/theme.spec.ts
+++ b/src/theme/theme.spec.ts
@@ -107,5 +107,33 @@ describe("resolveTheme", () => {
     });
     expect(theme.colorsEnabled).toBe(true);
     expect(theme.diffSelected.backgroundColor).toBe("#222200");
+    // A background always comes with a foreground, even in colorless mode.
+    expect(theme.diffSelected.color).toBeTruthy();
+  });
+
+  it("drops a background whose foreground was turned off", () => {
+    const theme = resolveTheme({
+      ...noFile,
+      BAZ_COLOR_DIFF_ADDED_FG: "none",
+    });
+    expect(theme.diffAdded.color).toBeUndefined();
+    expect(theme.diffAdded.backgroundColor).toBeUndefined();
+  });
+
+  it("ignores non-string values in a theme file", () => {
+    const file = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "baz-theme-")),
+      "theme.json",
+    );
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ theme: 42, diffAddedBg: ["#fff"], main: "#123456" }),
+    );
+
+    const theme = resolveTheme({ BAZ_THEME_FILE: file, COLORFGBG: "15;0" });
+    // The bad theme name and color fall back to the detected defaults.
+    expect(theme.name).toBe("dark");
+    expect(theme.diffAdded.backgroundColor).toBe("#1e3b26");
+    expect(theme.main).toBe("#123456");
   });
 });

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -24,6 +24,8 @@ export interface ThemeColors {
   main?: string;
   /** Secondary/emphasis color, e.g. selected PR title. */
   accent?: string;
+  /** Normal body text, for places that must not inherit the terminal's own. */
+  text?: string;
   success?: string;
   warning?: string;
   error?: string;
@@ -57,6 +59,7 @@ export interface Theme extends ThemeColors {
 const DARK_COLORS: ThemeColors = {
   main: "#9d9df0",
   accent: "#f2c96b",
+  text: "#e6e6f0",
   success: "#5fd7a0",
   warning: "#e5c07b",
   error: "#ff6b81",
@@ -76,6 +79,7 @@ const DARK_COLORS: ThemeColors = {
 const LIGHT_COLORS: ThemeColors = {
   main: "#5656c4",
   accent: "#a35a00",
+  text: "#1c1c22",
   success: "#137333",
   warning: "#8a6100",
   error: "#c5221f",
@@ -157,9 +161,13 @@ export function detectTerminalBackground(
   return "dark";
 }
 
+/**
+ * Reads the first theme file that exists, keeping only string values - a
+ * hand-edited file can hold anything, and a bad value must not break startup.
+ */
 function readOverridesFile(
   environment: NodeJS.ProcessEnv,
-): Partial<ThemeColors> & { theme?: string } {
+): Record<string, string> {
   const candidates = [
     environment.BAZ_THEME_FILE,
     path.join(process.cwd(), ".baz", "theme.json"),
@@ -172,7 +180,11 @@ function readOverridesFile(
       if (!fs.existsSync(file)) continue;
       const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf8"));
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        return parsed as Partial<ThemeColors> & { theme?: string };
+        return Object.fromEntries(
+          Object.entries(parsed).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string",
+          ),
+        );
       }
     } catch {
       // A broken theme file must never break the CLI - fall through to defaults.
@@ -182,9 +194,25 @@ function readOverridesFile(
   return {};
 }
 
-function styleOf(fg?: string, bg?: string, boldWhenPlain = false): TextStyle {
-  if (!fg && !bg) return boldWhenPlain ? { bold: true } : {};
-  return { color: fg, backgroundColor: bg };
+/**
+ * Builds a style, never emitting a background without a foreground - that
+ * combination is what made diffs unreadable on dark terminals.
+ *
+ * A background with no color of its own borrows `fallbackFg` (from the
+ * detected palette). A foreground explicitly turned off drops the background
+ * with it, since the user asked for unstyled text.
+ */
+function styleOf(
+  fg: string | undefined,
+  bg: string | undefined,
+  options: { fallbackFg?: string; boldWhenPlain?: boolean } = {},
+): TextStyle {
+  const { fallbackFg, boldWhenPlain = false } = options;
+  const color = fg ?? (bg ? fallbackFg : undefined);
+  const backgroundColor = color ? bg : undefined;
+
+  if (!color && !backgroundColor) return boldWhenPlain ? { bold: true } : {};
+  return { color, backgroundColor };
 }
 
 export function resolveTheme(
@@ -212,13 +240,30 @@ export function resolveTheme(
   const base: ThemeColors =
     name === "none" ? {} : name === "light" ? LIGHT_COLORS : DARK_COLORS;
 
+  // Backgrounds that survive into colorless mode still need a legible
+  // foreground, so keep the palette the terminal would have used.
+  const fallback: ThemeColors =
+    detectTerminalBackground(environment) === "light"
+      ? LIGHT_COLORS
+      : DARK_COLORS;
+
   const colors: ThemeColors = {};
+  const turnedOff = new Set<keyof ThemeColors>();
   for (const key of COLOR_KEYS) {
     const fromEnv = environment[envVarNameFor(key)];
-    const override =
-      fromEnv !== undefined ? fromEnv : (fileOverrides[key] as unknown);
-    colors[key] = override !== undefined ? normalizeColor(override) : base[key];
+    const override = fromEnv !== undefined ? fromEnv : fileOverrides[key];
+    if (override === undefined) {
+      colors[key] = base[key];
+      continue;
+    }
+    colors[key] = normalizeColor(override);
+    if (colors[key] === undefined) turnedOff.add(key);
   }
+
+  // A foreground the user turned off explicitly has no fallback: the paired
+  // background goes with it.
+  const fallbackFor = (key: keyof ThemeColors): string | undefined =>
+    turnedOff.has(key) ? undefined : fallback[key];
 
   const colorsEnabled = COLOR_KEYS.some((key) => Boolean(colors[key]));
 
@@ -226,13 +271,23 @@ export function resolveTheme(
     ...colors,
     name,
     colorsEnabled,
-    fileHeader: styleOf(colors.fileHeaderFg, colors.fileHeaderBg, true),
-    diffAdded: styleOf(colors.diffAddedFg, colors.diffAddedBg),
-    diffDeleted: styleOf(colors.diffDeletedFg, colors.diffDeletedBg),
+    fileHeader: styleOf(colors.fileHeaderFg, colors.fileHeaderBg, {
+      fallbackFg: fallbackFor("fileHeaderFg"),
+      boldWhenPlain: true,
+    }),
+    diffAdded: styleOf(colors.diffAddedFg, colors.diffAddedBg, {
+      fallbackFg: fallbackFor("diffAddedFg"),
+    }),
+    diffDeleted: styleOf(colors.diffDeletedFg, colors.diffDeletedBg, {
+      fallbackFg: fallbackFor("diffDeletedFg"),
+    }),
     // Without colors, the commented-on lines still need to stand out.
-    diffSelected: styleOf(colors.diffSelectedFg, colors.diffSelectedBg, true),
-    diffContext: styleOf(colors.diffContextFg),
-    lineNumber: styleOf(colors.lineNumberFg),
+    diffSelected: styleOf(colors.diffSelectedFg, colors.diffSelectedBg, {
+      fallbackFg: fallbackFor("diffSelectedFg"),
+      boldWhenPlain: true,
+    }),
+    diffContext: styleOf(colors.diffContextFg, undefined),
+    lineNumber: styleOf(colors.lineNumberFg, undefined),
   };
 }
 

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,0 +1,250 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Terminal theming for the review UI.
+ *
+ * Colors adapt to the terminal background (dark / light), can be forced with
+ * `BAZ_THEME`, turned off entirely (`BAZ_THEME=none`, `NO_COLOR`) and
+ * overridden key-by-key through env vars or a config file. See README.
+ */
+
+export type ThemeName = "dark" | "light" | "none";
+
+export interface TextStyle {
+  color?: string;
+  backgroundColor?: string;
+  bold?: boolean;
+}
+
+/** Every customizable color key. */
+export interface ThemeColors {
+  /** Brand color: headers, titles, spinners. */
+  main?: string;
+  /** Secondary/emphasis color, e.g. selected PR title. */
+  accent?: string;
+  success?: string;
+  warning?: string;
+  error?: string;
+  info?: string;
+  /** File header row of a diff. */
+  fileHeaderBg?: string;
+  fileHeaderFg?: string;
+  diffAddedBg?: string;
+  diffAddedFg?: string;
+  diffDeletedBg?: string;
+  diffDeletedFg?: string;
+  /** The lines a comment points at. */
+  diffSelectedBg?: string;
+  diffSelectedFg?: string;
+  /** Unchanged context lines and their line numbers. */
+  diffContextFg?: string;
+  lineNumberFg?: string;
+}
+
+export interface Theme extends ThemeColors {
+  name: ThemeName;
+  colorsEnabled: boolean;
+  fileHeader: TextStyle;
+  diffAdded: TextStyle;
+  diffDeleted: TextStyle;
+  diffSelected: TextStyle;
+  diffContext: TextStyle;
+  lineNumber: TextStyle;
+}
+
+const DARK_COLORS: ThemeColors = {
+  main: "#9d9df0",
+  accent: "#f2c96b",
+  success: "#5fd7a0",
+  warning: "#e5c07b",
+  error: "#ff6b81",
+  info: "#7fb4ff",
+  fileHeaderBg: "#3b3b4d",
+  fileHeaderFg: "#e8e8f5",
+  diffAddedBg: "#1e3b26",
+  diffAddedFg: "#b9f0c4",
+  diffDeletedBg: "#4a1f28",
+  diffDeletedFg: "#ffbecb",
+  diffSelectedBg: "#4a4324",
+  diffSelectedFg: "#ffe9a8",
+  diffContextFg: "#c8c8d2",
+  lineNumberFg: "#8a8a99",
+};
+
+const LIGHT_COLORS: ThemeColors = {
+  main: "#5656c4",
+  accent: "#a35a00",
+  success: "#137333",
+  warning: "#8a6100",
+  error: "#c5221f",
+  info: "#1a56b0",
+  fileHeaderBg: "#d3d3d3",
+  fileHeaderFg: "#1c1c22",
+  diffAddedBg: "#9aff9a",
+  diffAddedFg: "#0a3312",
+  diffDeletedBg: "#ff82ab",
+  diffDeletedFg: "#3d0013",
+  diffSelectedBg: "#fff59d",
+  diffSelectedFg: "#3a2f00",
+  diffContextFg: "#1c1c22",
+  lineNumberFg: "#5c5c66",
+};
+
+const COLOR_KEYS = Object.keys(DARK_COLORS) as (keyof ThemeColors)[];
+
+/** `diffAddedBg` -> `BAZ_COLOR_DIFF_ADDED_BG` */
+function envVarNameFor(key: keyof ThemeColors): string {
+  return `BAZ_COLOR_${key.replace(/([A-Z])/g, "_$1").toUpperCase()}`;
+}
+
+const DISABLED_VALUES = new Set(["", "none", "off", "false", "default"]);
+
+/** Returns the color, or `undefined` when the value means "no color". */
+function normalizeColor(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (DISABLED_VALUES.has(trimmed.toLowerCase())) return undefined;
+  return trimmed;
+}
+
+function parseThemeName(value: string | undefined): ThemeName | "auto" | null {
+  switch (value?.trim().toLowerCase()) {
+    case "dark":
+      return "dark";
+    case "light":
+      return "light";
+    case "none":
+    case "off":
+    case "no":
+    case "no-color":
+    case "mono":
+      return "none";
+    case "auto":
+      return "auto";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Best-effort detection of the terminal background.
+ *
+ * `COLORFGBG` is set by several terminals (iTerm2, urxvt, Konsole) as
+ * `fg;bg`, where a low background index means a dark background. When nothing
+ * says otherwise we assume dark, which is the common default.
+ */
+export function detectTerminalBackground(
+  environment: NodeJS.ProcessEnv = process.env,
+): "dark" | "light" {
+  const explicit = environment.BAZ_TERMINAL_BACKGROUND?.trim().toLowerCase();
+  if (explicit === "light" || explicit === "dark") return explicit;
+
+  const colorFgBg = environment.COLORFGBG;
+  if (colorFgBg) {
+    const background = colorFgBg.split(";").pop()?.trim();
+    if (background === "default") return "dark";
+    const index = Number(background);
+    if (Number.isFinite(index)) {
+      // 0-6 and 8 are dark backgrounds; 7 and 9-15 are light ones.
+      return index === 7 || index > 8 ? "light" : "dark";
+    }
+  }
+
+  if (environment.TERM === "linux") return "dark";
+
+  return "dark";
+}
+
+function readOverridesFile(
+  environment: NodeJS.ProcessEnv,
+): Partial<ThemeColors> & { theme?: string } {
+  const candidates = [
+    environment.BAZ_THEME_FILE,
+    path.join(process.cwd(), ".baz", "theme.json"),
+    path.join(os.homedir(), ".baz", "theme.json"),
+    path.join(os.homedir(), ".config", "baz", "theme.json"),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  for (const file of candidates) {
+    try {
+      if (!fs.existsSync(file)) continue;
+      const parsed: unknown = JSON.parse(fs.readFileSync(file, "utf8"));
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Partial<ThemeColors> & { theme?: string };
+      }
+    } catch {
+      // A broken theme file must never break the CLI - fall through to defaults.
+    }
+  }
+
+  return {};
+}
+
+function styleOf(fg?: string, bg?: string, boldWhenPlain = false): TextStyle {
+  if (!fg && !bg) return boldWhenPlain ? { bold: true } : {};
+  return { color: fg, backgroundColor: bg };
+}
+
+export function resolveTheme(
+  environment: NodeJS.ProcessEnv = process.env,
+): Theme {
+  const fileOverrides = readOverridesFile(environment);
+
+  const requested =
+    parseThemeName(environment.BAZ_THEME) ??
+    parseThemeName(fileOverrides.theme) ??
+    "auto";
+
+  const noColorRequested =
+    requested === "none" ||
+    // https://no-color.org - any non-empty value disables color.
+    Boolean(environment.NO_COLOR) ||
+    environment.TERM === "dumb";
+
+  const name: ThemeName = noColorRequested
+    ? "none"
+    : requested === "auto"
+      ? detectTerminalBackground(environment)
+      : requested;
+
+  const base: ThemeColors =
+    name === "none" ? {} : name === "light" ? LIGHT_COLORS : DARK_COLORS;
+
+  const colors: ThemeColors = {};
+  for (const key of COLOR_KEYS) {
+    const fromEnv = environment[envVarNameFor(key)];
+    const override =
+      fromEnv !== undefined ? fromEnv : (fileOverrides[key] as unknown);
+    colors[key] = override !== undefined ? normalizeColor(override) : base[key];
+  }
+
+  const colorsEnabled = COLOR_KEYS.some((key) => Boolean(colors[key]));
+
+  return {
+    ...colors,
+    name,
+    colorsEnabled,
+    fileHeader: styleOf(colors.fileHeaderFg, colors.fileHeaderBg, true),
+    diffAdded: styleOf(colors.diffAddedFg, colors.diffAddedBg),
+    diffDeleted: styleOf(colors.diffDeletedFg, colors.diffDeletedBg),
+    // Without colors, the commented-on lines still need to stand out.
+    diffSelected: styleOf(colors.diffSelectedFg, colors.diffSelectedBg, true),
+    diffContext: styleOf(colors.diffContextFg),
+    lineNumber: styleOf(colors.lineNumberFg),
+  };
+}
+
+let cached: Theme | null = null;
+
+/** The active theme. Resolved once per process. */
+export function getTheme(): Theme {
+  cached ??= resolveTheme();
+  return cached;
+}
+
+/** Test helper - drops the memoized theme. */
+export function resetTheme(): void {
+  cached = null;
+}


### PR DESCRIPTION
## Problem

Two issues with the PR comments review UI:

1. **Small windows are unusable.** The comment, its diff and the conversation were rendered at full height, so on a short (but wide) window the input box and its hints were pushed off screen and the terminal scrolled the frame away. Nothing could be scrolled back either.
2. **Dark terminals are unreadable.** Diff rows and the file header set a `backgroundColor` without a matching text color, so light pastel backgrounds were painted under the terminal's own light foreground. Colors were hardcoded, with no way to adapt or turn them off.

## Changes

### Scrolling

- New `ScrollableViewport` clips its content to the rows the terminal has left and scrolls with `↑`/`↓`, `PgUp`/`PgDn` and `Ctrl+U`/`Ctrl+D`. A status line reports the visible range (`↑↓ lines 12-30 of 84`). It follows new chat output, unless the user has scrolled up.
- New `ScreenLayout` context: chrome that must stay on screen (banner, selected-PR line, chat input) measures itself and reports its height, so the viewport sizes itself to whatever is left. No fixed root height, so screens without a viewport still overflow into the terminal's own scrollback rather than being silently truncated.
- Chrome adapts too: below 24 rows the banner drops to one line and the input hints collapse onto one line — their rows cost more than they are worth in a short window.
- Applied to the comments browser, PR chat, and the met/unmet requirement browsers.

### Theming

- New `src/theme/theme.ts` resolves a theme once per process:
  - adapts to the terminal background (`COLORFGBG` where available, dark assumed otherwise),
  - `BAZ_THEME=auto|dark|light|none`, `BAZ_TERMINAL_BACKGROUND=dark|light`, and `NO_COLOR` support,
  - every color overridable via `BAZ_COLOR_*` env vars or a `theme.json` (`$BAZ_THEME_FILE`, `./.baz/`, `~/.baz/`, `~/.config/baz/`), with `none` to unstyle a single element.
- A background is now always paired with a readable foreground — the actual dark-mode fix. Without colors, the lines a comment points at are bold instead.
- Hardcoded `"cyan"`/`"magenta"`/`"red"` colors in the review path now come from the theme, so they honor `NO_COLOR`.
- `theme/colors.ts` keeps its exports, now theme-derived, so untouched screens follow along.

Documented under **Appearance** in the README.

## Testing

- `npm run cicd` (lint, format, 192 tests, build) passes.
- New tests: theme resolution/detection/overrides (`src/theme/theme.spec.ts`) and viewport behavior — clipping, chrome staying on screen, arrow/PgDn scrolling, clamping at the end, no hint when the window is tall (`src/components/ScrollableViewport.spec.tsx`).
- Manually drove the **compiled** `dist/` UI in a real pty at 8-18 rows: the frame fits the window at every size, real `PgDn` scrolls from the comment through to the diff, and the input box and hints stay visible. Verified dark (`#4a4324` bg + `#ffe9a8` fg on the commented lines), light (`#fff59d` + `#3a2f00`) and `NO_COLOR` (no color codes, bold selection) output.

Note: the live comments screen needs a logged-in session, so end-to-end verification used the compiled components with fixture data rather than a real PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)