### PR TITLE
fix: stop infinite interactive-login loop on repeated 401s

### DIFF
--- a/src/lib/clients/axios/axios-client.ts
+++ b/src/lib/clients/axios/axios-client.ts
@@ -85,28 +85,38 @@ export const createAxiosClient = (baseURL: string) => {
 
         isAuthenticating = true;
 
+        // Keep isAuthenticating held until the replayed request settles, not
+        // just until authenticate() resolves. Otherwise the guard clears while
+        // the replay is still in flight, letting a concurrent 401 start a
+        // second OAuth flow that overwrites the token the replay is using.
         try {
-          console.log(
-            chalk.yellow(
-              "⚠️  Authentication required. Initiating login flow...",
-            ),
-          );
-          tokenMgr.resetToken();
-
           const oauthFlow = OAuthFlow.getInstance();
-          await oauthFlow.authenticate(authConfig);
+
+          try {
+            console.log(
+              chalk.yellow(
+                "⚠️  Authentication required. Initiating login flow...",
+              ),
+            );
+            tokenMgr.resetToken();
+            await oauthFlow.authenticate(authConfig);
+          } catch (authError) {
+            console.error(
+              chalk.red("❌ Authentication failed:"),
+              authError instanceof Error ? authError.message : "Unknown error",
+            );
+            return Promise.reject(error);
+          }
 
           const token = oauthFlow.getAccessToken();
           if (token && error.config) {
             error.config.headers.Authorization = `Bearer ${token}`;
             error.config._bazAuthRetried = true;
-            return axiosClient.request(error.config);
+            // Awaited so the guard (cleared in finally) stays set until the
+            // replay resolves. A repeat 401 is handled by the _bazAuthRetried
+            // branch above and propagates without re-triggering login.
+            return await axiosClient.request(error.config);
           }
-        } catch (authError) {
-          console.error(
-            chalk.red("❌ Authentication failed:"),
-            authError instanceof Error ? authError.message : "Unknown error",
-          );
           return Promise.reject(error);
         } finally {
           isAuthenticating = false;

--- a/src/lib/clients/axios/axios-client.ts
+++ b/src/lib/clients/axios/axios-client.ts
@@ -7,6 +7,13 @@ import { authConfig } from "../../../auth/config.js";
 import { getAppConfig } from "../../config/app-mode.js";
 import { env } from "../../env-schema.js";
 
+declare module "axios" {
+  interface InternalAxiosRequestConfig {
+    /** Set once we've retried a request after a 401 re-auth, to avoid loops. */
+    _bazAuthRetried?: boolean;
+  }
+}
+
 export interface TokenManager {
   getToken: () => string;
   resetToken: () => void;
@@ -51,6 +58,27 @@ export const createAxiosClient = (baseURL: string) => {
     },
     async function (error) {
       if (error?.response?.status === 401) {
+        // If we already re-authenticated for this request and it still 401s,
+        // the credentials are being rejected by the server. Re-running the
+        // login flow would loop forever (and collide on the callback port),
+        // so surface a clear error instead of retrying again.
+        if (error.config?._bazAuthRetried) {
+          console.error(
+            chalk.red(
+              "❌ The Baz API rejected your credentials even after re-authenticating.",
+            ),
+          );
+          console.error(
+            chalk.red(
+              "   Your login succeeded but your account may not have access to this API. " +
+                "Please contact Baz support.",
+            ),
+          );
+          return Promise.reject(error);
+        }
+
+        // Guard against concurrent requests all kicking off their own
+        // interactive login (which would collide on the OAuth callback port).
         if (isAuthenticating) {
           return Promise.reject(error);
         }
@@ -71,19 +99,18 @@ export const createAxiosClient = (baseURL: string) => {
           const token = oauthFlow.getAccessToken();
           if (token && error.config) {
             error.config.headers.Authorization = `Bearer ${token}`;
-            isAuthenticating = false;
+            error.config._bazAuthRetried = true;
             return axiosClient.request(error.config);
           }
         } catch (authError) {
-          isAuthenticating = false;
           console.error(
             chalk.red("❌ Authentication failed:"),
             authError instanceof Error ? authError.message : "Unknown error",
           );
           return Promise.reject(error);
+        } finally {
+          isAuthenticating = false;
         }
-
-        isAuthenticating = false;
       }
       if (error?.response?.status === 402) {
         tokenMgr.resetToken();


### PR DESCRIPTION
## What changed

The axios response interceptor (`src/lib/clients/axios/axios-client.ts`) reacted to **every** `401` from the Baz API by launching a full interactive browser OAuth flow, retrying the request, and — when the server still rejected the token — launching login **again**, indefinitely.

This PR makes a request re-authenticate **at most once**. If it still returns `401` after a fresh login, the CLI now surfaces a clear error and rejects, instead of looping. The `isAuthenticating` reset was also moved into a `finally` block so it is always cleared.

## Why

Reported as "the CLI gets stuck in loops on login" (seen on Windows). Reproduced locally:

- Login itself succeeds and stores a valid, unexpired token (`scope: full_access`).
- Requests to `https://baz.co/api/v2/...` nonetheless return `401`.
- The interceptor re-launched interactive login on each `401` → infinite loop.
- Each attempt reopened the OAuth callback server on the fixed port `8020`, so looping/concurrent attempts collided with `EADDRINUSE`, wedging the process (the observed "stuck fetching pull requests" hang, with an orphaned process still holding port 8020).

The underlying `401` appears to be a server-side account/entitlement issue against the migrated v2 API and is out of scope here — but a rejected credential should fail fast with a clear message rather than hang the CLI.

## Reviewer notes

- This only changes client retry/loop behavior; it does not touch the OAuth flow or token storage.
- Follow-ups worth considering (not included):
  - Use the stored **refresh token** for a silent refresh on `401` instead of a full browser flow (a refresh token is saved but never used).
  - Use a **dynamic/free callback port** instead of the hardcoded `8020`, which is more robust on locked-down environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
