### PR TITLE
ci: run the test suite on pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,6 +38,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Run tests
+        run: npm test
       - name: Build project
         run: npm run build
       - name: Create package

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # These jobs run code from the pull request (install scripts,
+          # tests, the packaged CLI) and never push, so the checkout must
+          # not leave the job token readable in .git/config.
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -32,6 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          # These jobs run code from the pull request (install scripts,
+          # tests, the packaged CLI) and never push, so the checkout must
+          # not leave the job token readable in .git/config.
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    // Only the sources. `tsc` copies the specs into `dist/`, and stale builds
+    // and git worktrees leave more copies around, so an unscoped run collects
+    // the same test several times over — and fails on copies whose source is
+    // long gone.
+    include: ["src/**/*.spec.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Problem

The `build-test` job in `.github/workflows/pr.yml` installs, builds, packs, installs the tarball and runs `baz -h` — but never runs a test. Nothing under `src/**/*.spec.*` gates a merge today, so a regression test can go red while CI stays green.

Split out of #120, where a new regression test would not have been run by CI.

## Change

- `pr.yml`: add a `Run tests` step to `build-test`, before the build so it fails fast.
- `vitest.config.ts`: scope collection to `include: ["src/**/*.spec.{ts,tsx}"]`.

The Vitest scoping is needed for the CI step to be meaningful. `tsc` copies every spec into `dist/`, and stale builds and git worktrees leave further copies around, so an unscoped run collects the same test two or three times — and fails outright on copies whose source no longer exists (a `dist/components/ScrollableViewport.spec.js` with no counterpart in `src/` currently does exactly that locally).

## Verification

On this branch: `npx vitest run` collects 2 files / 60 tests from `src/` only (was 12 files / 264, mostly duplicates of the same specs). `npm run lint` and `npm run format:check` pass.

Note: `tsc` still emits the specs into `dist/`, so they ship in the package. Excluding them from the build would also stop type-checking them, so I left that alone — worth a separate look if the packaged size matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)