### PR TITLE
test: fix ScrollableViewport specs failing in CI

### DIFF
--- a/src/components/ScrollableViewport.spec.tsx
+++ b/src/components/ScrollableViewport.spec.tsx
@@ -90,6 +90,9 @@ async function renderHarness(rows: number, props: HarnessProps = {}) {
   const instance = render(<Harness {...props} />, {
     stdout: stdout.stream as unknown as NodeJS.WriteStream,
     stdin: stdin as unknown as NodeJS.ReadStream,
+    // Without this Ink detects `CI` and writes nothing until unmount, so the
+    // frames below come back empty on the runner.
+    debug: true,
     patchConsole: false,
   });
 


### PR DESCRIPTION
## Summary
- Render the `ScrollableViewport` spec harness with Ink's `debug` option. Ink's `is-in-ci` sees `CI=true` on the runner and holds every stdout write back until unmount, so the harness read an empty stream and each assertion got back the bare `"BANNER"` prefix `lastFrame` prepends. Debug mode writes whole frames regardless of CI — the same thing the shared `renderInk` helper already does, which is why `ReviewMenu.spec.tsx` was unaffected.

## Test plan
- [x] `CI=true npm test` passes locally (86/86)
- [x] CI run on this PR is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)